### PR TITLE
feat: thread_ts キーで履歴保存

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,16 +2,26 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 
 from slack_agent.cache import InMemoryCacheStore
+from slack_agent.checkpointer import create_checkpointer
 from slack_agent.config import build_llm, load_config, _expand_recursive
 from slack_agent.graph import build_graph
 from slack_agent.slack_handler import create_app, run_app
 from slack_agent.tools import load_mcp_tools, make_cache_fetcher_tool, _load_server_tools
 
-logging.basicConfig(level=logging.INFO)
+# DEBUG_LLM=1 で LangChain の verbose/debug を有効にし、LLM への入出力を全部出す
+if os.environ.get("DEBUG_LLM"):
+    from langchain_core.globals import set_debug, set_verbose
+    set_debug(True)
+    set_verbose(True)
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +82,9 @@ async def main():
         extra_prompt = prompt_path.read_text()
         logger.info("Loaded prompt.md as initial prompt")
 
+    checkpointer = create_checkpointer(config.storage)
+    logger.info("Checkpointer initialized: type=%s", config.storage.type)
+
     compiled_graph = build_graph(
         config=config,
         standard_llm=standard_llm,
@@ -79,6 +92,7 @@ async def main():
         tools_by_name=tools_by_name,
         cache_store=cache_store,
         extra_prompt=extra_prompt,
+        checkpointer=checkpointer,
     )
 
     app = create_app(config, compiled_graph, config.agent)

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,3 +1,8 @@
 {
-    "mcpServers": {}
+    "mcpServers": {
+        "fetch": {
+            "command": "uvx",
+            "args": ["mcp-server-fetch"]
+        }
+    }
 }

--- a/settings.json
+++ b/settings.json
@@ -5,9 +5,9 @@
     "allowed_user_ids": []
   },
   "models": {
-    "provider": "bedrock",
-    "standard": "global.anthropic.claude-sonnet-4-6",
-    "light": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "provider": "openai",
+    "standard": "gpt-5-nano-2025-08-07",
+    "light": "gpt-5-nano-2025-08-07",
     "options": {}
   },
   "retry": {
@@ -20,5 +20,8 @@
   "agent": {
     "compression_threshold_bytes": 10000,
     "recursion_limit": 25
+  },
+  "storage": {
+    "type": "memory"
   }
 }

--- a/slack_agent/checkpointer.py
+++ b/slack_agent/checkpointer.py
@@ -1,0 +1,38 @@
+"""LangGraph checkpointer のファクトリ。
+
+Slack の thread_ts を thread_id として AgentState 全体を保存・復元するため、
+LangGraph の checkpointer を生成するファクトリを提供する。
+
+将来 sqlite/postgres バックエンドを追加する際は:
+- create_checkpointer の dispatch に case を追加する
+- 依存パッケージは optional-dependencies として追加する
+  (例: langgraph-checkpoint-sqlite, langgraph-checkpoint-postgres)
+- StorageConfig に必要なフィールド (path, dsn 等) を追加する
+"""
+
+import logging
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import MemorySaver
+
+from .config import StorageConfig
+
+logger = logging.getLogger(__name__)
+
+
+def create_checkpointer(cfg: StorageConfig) -> BaseCheckpointSaver:
+    """StorageConfig に基づいて checkpointer を生成する。
+
+    現状は "memory" のみ対応。未知のタイプは ValueError を投げる。
+    """
+    if cfg.type == "memory":
+        logger.info("Using MemorySaver checkpointer (in-memory, non-persistent)")
+        return MemorySaver()
+    # 将来の拡張ポイント:
+    # if cfg.type == "sqlite":
+    #     from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+    #     return AsyncSqliteSaver.from_conn_string(cfg.path)
+    # if cfg.type == "postgres":
+    #     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    #     return AsyncPostgresSaver.from_conn_string(cfg.dsn)
+    raise ValueError(f"Unknown storage type: {cfg.type!r}")

--- a/slack_agent/config.py
+++ b/slack_agent/config.py
@@ -62,6 +62,15 @@ class AgentConfig:
 
 
 @dataclass
+class StorageConfig:
+    """LangGraph checkpointer のバックエンド設定。
+
+    type: "memory" のみ対応。将来 sqlite/postgres を追加予定。
+    """
+    type: str
+
+
+@dataclass
 class AppConfig:
     slack: SlackConfig
     standard_model: ModelConfig
@@ -69,6 +78,7 @@ class AppConfig:
     retry: RetryConfig
     cache: CacheConfig
     agent: AgentConfig
+    storage: StorageConfig
 
 
 def load_config(settings_path: str = "settings.json") -> AppConfig:
@@ -103,6 +113,9 @@ def load_config(settings_path: str = "settings.json") -> AppConfig:
         recursion_limit=agent_raw.get("recursion_limit", 25),
     )
 
+    storage_raw = raw.get("storage", {"type": "memory"})
+    storage = StorageConfig(type=storage_raw.get("type", "memory"))
+
     return AppConfig(
         slack=slack,
         standard_model=standard_model,
@@ -110,6 +123,7 @@ def load_config(settings_path: str = "settings.json") -> AppConfig:
         retry=retry,
         cache=cache,
         agent=agent,
+        storage=storage,
     )
 
 

--- a/slack_agent/graph.py
+++ b/slack_agent/graph.py
@@ -4,6 +4,7 @@ from typing import Callable
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph import END, StateGraph
 
 from .cache import CacheStore
@@ -39,6 +40,7 @@ def build_graph(
     tools_by_name: dict,
     cache_store: CacheStore,
     extra_prompt: str = "",
+    checkpointer: BaseCheckpointSaver | None = None,
 ):
     graph = StateGraph(AgentState)
 
@@ -72,4 +74,4 @@ def build_graph(
     })
     graph.add_edge("compressor", "orchestrator")
 
-    return graph.compile()
+    return graph.compile(checkpointer=checkpointer)

--- a/slack_agent/nodes.py
+++ b/slack_agent/nodes.py
@@ -71,6 +71,18 @@ async def orchestrator_node(
     system_msg = SystemMessage(content=_build_orchestrator_system(state.get("cache_references", []), extra_prompt))
     messages = [system_msg] + list(state["messages"])
 
+    logger.info("orchestrator invoke: %d messages", len(messages))
+    for i, m in enumerate(messages):
+        tc = getattr(m, "tool_calls", None)
+        tcid = getattr(m, "tool_call_id", None)
+        logger.info(
+            "  [%d] %s tool_calls=%s tool_call_id=%s content=%r",
+            i, type(m).__name__,
+            [c.get("name") for c in tc] if tc else None,
+            tcid,
+            (str(m.content)[:80] if m.content else "")
+        )
+
     async def _invoke():
         return await standard_llm.ainvoke(messages)
 
@@ -224,9 +236,12 @@ async def compressor_node(
                 )
             )
 
+        # 元 ToolMessage の id を引き継ぐことで、add_messages reducer に
+        # 「追加」ではなく「置換」と認識させる (checkpointer 利用時の重複防止)
         compressed_msg = ToolMessage(
             content=f"[Compressed]\n{focused_summary}",
             tool_call_id=msg.tool_call_id,
+            id=msg.id,
         )
         updated_messages.append(compressed_msg)
 

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import re
 
 from langchain_core.messages import HumanMessage
 from slack_bolt.async_app import AsyncApp
@@ -6,45 +8,32 @@ from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
 from .config import AppConfig
 from .state import AgentState
+from .thread_history import fetch_new_replies
 
 logger = logging.getLogger(__name__)
 
 _ERROR_MESSAGE = "申し訳ありません。エラーが発生しました。しばらくしてから再度お試しください。"
+_MENTION_PATTERN = re.compile(r"<@[^>]+>")
 
 
 def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
     app = AsyncApp(token=config.slack.bot_token)
 
-    async def _fetch_thread_context(client, channel: str, thread_ts: str, bot_user_id: str, current_ts: str) -> str | None:
-        """スレッドの過去メッセージをシステムプロンプト用のテキストとして返す"""
-        try:
-            result = await client.conversations_replies(
-                channel=channel,
-                ts=thread_ts,
-            )
-        except Exception as exc:
-            logger.warning("Failed to fetch thread replies: %s", exc)
-            return None
+    # bot_user_id を memoize するためのクロージャ。auth_test の二重実行を避けるため
+    # asyncio.Lock で初回取得を直列化する。
+    bot_user_id_holder: dict[str, str] = {}
+    bot_user_id_lock = asyncio.Lock()
 
-        import re
-        lines = []
-        for msg in result.get("messages", []):
-            if msg.get("subtype") is not None:
-                continue
-            if msg.get("ts") == current_ts:
-                continue
-            msg_text = re.sub(r"<@[^>]+>", "", msg.get("text", "")).strip()
-            if not msg_text:
-                continue
-            if msg.get("user") == bot_user_id or msg.get("bot_id"):
-                role = "assistant"
-            else:
-                role = "user"
-            lines.append(f"[{role}]: {msg_text}")
-
-        if not lines:
-            return None
-        return "Previous thread context:\n" + "\n".join(lines)
+    async def _get_bot_user_id(client) -> str:
+        if "id" in bot_user_id_holder:
+            return bot_user_id_holder["id"]
+        async with bot_user_id_lock:
+            if "id" in bot_user_id_holder:
+                return bot_user_id_holder["id"]
+            auth_result = await client.auth_test()
+            bot_user_id_holder["id"] = auth_result.get("user_id", "")
+            logger.info("Resolved bot_user_id=%s", bot_user_id_holder["id"])
+            return bot_user_id_holder["id"]
 
     async def _handle_message(body: dict, say, client):
         event = body.get("event", {})
@@ -55,8 +44,7 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
         thread_ts = event.get("thread_ts") or event_ts
 
         # Strip bot mention from text
-        import re
-        text = re.sub(r"<@[^>]+>", "", text).strip()
+        text = _MENTION_PATTERN.sub("", text).strip()
 
         # Check allowed users
         allowed = config.slack.allowed_user_ids
@@ -64,12 +52,44 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             logger.info("User %s not in allowed list, ignoring", user_id)
             return
 
-        # スレッドの過去メッセージを取得（スレッド内の場合）
-        thread_context: str | None = None
-        if event.get("thread_ts"):
-            auth_result = await client.auth_test()
-            bot_user_id = auth_result.get("user_id", "")
-            thread_context = await _fetch_thread_context(client, channel, thread_ts, bot_user_id, event_ts)
+        gconfig = {"configurable": {"thread_id": thread_ts}}
+
+        # checkpoint から prior state を取得し、差分取得 or フォールバックを判定
+        prior_values: dict = {}
+        try:
+            prior = await compiled_graph.aget_state(gconfig)
+            prior_values = prior.values if prior else {}
+        except Exception as exc:
+            logger.warning("Failed to get prior state for thread=%s: %s", thread_ts, exc)
+
+        messages_in_state = prior_values.get("messages", [])
+        last_bot_response_ts = prior_values.get("last_bot_response_ts")
+
+        # messages_in_state が空 = checkpoint 無し / 再起動後 -> 全件フォールバック
+        # 非空 -> last_bot_response_ts 以降の差分のみ取得
+        if not messages_in_state:
+            since_ts = None
+            mode = "fallback"
+        else:
+            since_ts = last_bot_response_ts
+            mode = "diff"
+
+        bot_user_id = await _get_bot_user_id(client)
+        new_replies = await fetch_new_replies(
+            client,
+            channel=channel,
+            thread_root_ts=thread_ts,
+            since_ts=since_ts,
+            current_ts=event_ts,
+            bot_user_id=bot_user_id,
+        )
+
+        logger.info(
+            "thread=%s mode=%s prior_messages=%d new_replies=%d since=%s event_ts=%s text=%r",
+            thread_ts, mode, len(messages_in_state), len(new_replies), since_ts, event_ts, text[:60],
+        )
+        for i, m in enumerate(new_replies):
+            logger.info("  new_replies[%d]: %r", i, str(m.content)[:80])
 
         # 進捗メッセージ: 1件のみ投稿し、推論ステップを追記しながら更新
         progress_ts: list[str] = []
@@ -92,11 +112,10 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
                     text=combined,
                 )
 
-        human_message = HumanMessage(
-            content=f"{thread_context}\n\n{text}" if thread_context else text
-        )
+        current_human = HumanMessage(content=text)
+        # last_bot_response_ts は initial_state に含めない (既存値を維持)
         initial_state: AgentState = {
-            "messages": [human_message],
+            "messages": new_replies + [current_human],
             "compression_threshold": agent_config.compression_threshold_bytes,
             "cache_references": [],
             "pending_progress_message": None,
@@ -107,7 +126,10 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
                 initial_state,
                 config={
                     "recursion_limit": agent_config.recursion_limit,
-                    "configurable": {"slack_notify": slack_notify},
+                    "configurable": {
+                        "slack_notify": slack_notify,
+                        "thread_id": thread_ts,
+                    },
                 },
             )
             final_message = final_state["messages"][-1]
@@ -117,11 +139,22 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             answer = _ERROR_MESSAGE
 
         # 最終回答は別メッセージとして投稿（進捗メッセージとは別スレッド返信）
-        await client.chat_postMessage(
+        result = await client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,
             text=answer,
         )
+
+        # 次回の差分取得整合性のため、エラー応答時も last_bot_response_ts を更新する
+        posted_ts = result.get("ts")
+        if posted_ts:
+            try:
+                await compiled_graph.aupdate_state(gconfig, {"last_bot_response_ts": posted_ts})
+            except Exception as exc:
+                logger.warning(
+                    "Failed to update last_bot_response_ts (thread=%s ts=%s): %s",
+                    thread_ts, posted_ts, exc,
+                )
 
     @app.event("message")
     async def handle_dm(body, say, client):

--- a/slack_agent/state.py
+++ b/slack_agent/state.py
@@ -21,3 +21,5 @@ class AgentState(TypedDict):
     compression_threshold: int
     cache_references: list[CacheReference]
     pending_progress_message: str | None
+    # 最後に bot が postMessage した ts。次回起動時の差分取得 (oldest) に使う
+    last_bot_response_ts: str | None

--- a/slack_agent/thread_history.py
+++ b/slack_agent/thread_history.py
@@ -1,0 +1,91 @@
+"""Slack スレッドの差分取得モジュール。
+
+LangGraph checkpointer に保存された state と組み合わせて、
+"最後の bot 発言以降の新規メッセージだけを取り込む" 差分取得を提供する。
+checkpoint が無い (since_ts is None) 場合は全件取得にフォールバックする。
+
+bot 自身の過去発言は AIMessage ではなく HumanMessage(content="[assistant said]: ...")
+として取り込む。これは tool_calls の整合性エラーを避けつつ、
+LLM に対して role 情報をテキストタグで伝えるための妥協策。
+"""
+
+import logging
+import re
+
+from langchain_core.messages import HumanMessage
+
+logger = logging.getLogger(__name__)
+
+_MENTION_PATTERN = re.compile(r"<@[^>]+>")
+
+
+async def fetch_new_replies(
+    client,
+    channel: str,
+    thread_root_ts: str,
+    since_ts: str | None,
+    current_ts: str,
+    bot_user_id: str,
+) -> list[HumanMessage]:
+    """スレッドから「最後の bot 発言より後」の新規メッセージを取得する。
+
+    Args:
+        client: Slack AsyncWebClient
+        channel: チャンネル ID
+        thread_root_ts: スレッドのルート ts
+        since_ts: 直近の bot 発言 ts。None なら全件取得 (フォールバック)
+        current_ts: 今回トリガーになった発言の ts (重複投入防止のためスキップ)
+        bot_user_id: 自分の bot user id (assistant 判定用)
+
+    Returns:
+        HumanMessage のリスト。assistant role のメッセージは
+        "[assistant said]: ..." の prefix 付きで HumanMessage として返す。
+        取得失敗時は空リスト。
+    """
+    kwargs = {"channel": channel, "ts": thread_root_ts}
+    if since_ts is not None:
+        kwargs["oldest"] = since_ts
+        kwargs["inclusive"] = False
+
+    try:
+        result = await client.conversations_replies(**kwargs)
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch thread replies (channel=%s thread=%s since=%s): %s",
+            channel, thread_root_ts, since_ts, exc,
+        )
+        return []
+
+    raw_msgs = result.get("messages", [])
+    logger.debug(
+        "conversations_replies returned %d messages (since=%s current_ts=%s)",
+        len(raw_msgs), since_ts, current_ts,
+    )
+    for m in raw_msgs:
+        logger.debug(
+            "  reply ts=%s user=%s bot_id=%s subtype=%s text=%r",
+            m.get("ts"), m.get("user"), m.get("bot_id"),
+            m.get("subtype"), (m.get("text") or "")[:80],
+        )
+
+    messages: list[HumanMessage] = []
+    for msg in raw_msgs:
+        if msg.get("subtype") is not None:
+            continue
+        if msg.get("ts") == current_ts:
+            continue
+        # Slack の conversations.replies は oldest を指定しても thread の親メッセージを
+        # 常に先頭に含める仕様。差分取得 (since_ts is not None) では既に過去の messages に
+        # 含まれているため除外する。フォールバック (since_ts is None) では取り込む。
+        if since_ts is not None and msg.get("ts") == thread_root_ts:
+            continue
+        text = _MENTION_PATTERN.sub("", msg.get("text", "")).strip()
+        if not text:
+            continue
+        is_assistant = msg.get("user") == bot_user_id or msg.get("bot_id")
+        if is_assistant:
+            messages.append(HumanMessage(content=f"[assistant said]: {text}"))
+        else:
+            messages.append(HumanMessage(content=text))
+
+    return messages


### PR DESCRIPTION
## Summary

- LangGraph checkpointer 入れた。MemorySaver で thread_ts ごとに State 保存
- 差分取得方式。oldest 使って前回 bot 投稿以降だけ取る。checkpoint 無い時は全件 fallback
- bot 発言は \`[assistant said]:\` prefix の HumanMessage で取り込む（tool_calls 整合エラー回避）
- compressor の id 引き継ぎバグ修正（checkpointer 入れたら ToolMessage 二重になってた）

closes #3

## やったこと

- \`slack_agent/checkpointer.py\` 新規。\`storage.type\` 設定でバックエンド選べる（今は memory のみ）
- \`slack_agent/thread_history.py\` 新規。差分 / fallback 取得を分離
- \`AgentState.last_bot_response_ts\` 追加。bot 投稿後に handler が \`aupdate_state\` で書く
- エラー応答時も ts 更新する
- Slack API は oldest 指定しても thread root を必ず返すので、since_ts ある時は除外
- bot_user_id は memoize（asyncio.Lock で初回二重実行防止）
- compressor の ToolMessage に id 引き継ぎ → add_messages reducer が置換扱いに

## やってないこと（別 PR）

- Anthropic prompt caching の cache_control 設定（過去 messages の順序は不変なので将来効く設計）
- 並行メッセージ対策の asyncio.Lock → #4 で対応

## Test plan

- [x] 新規スレッド: fallback 経路で初回応答
- [x] 同一スレッド継続: diff 経路で重複なし
- [x] tool 呼び出しあり: ToolMessage 重複しない
- [x] エラー応答後: 次回も diff で正しく since 更新される
- [x] プロセス再起動: MemorySaver なので checkpoint 飛ぶ → fallback で全件取り直し
- [x] DM での動作確認

## デバッグ

\`DEBUG_LLM=1\` で LangChain の verbose / debug 有効化できる