### PR TITLE
feat: support Slack Plan Block for AI agent progress display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,20 @@ FROM python:3.14-slim
 # Install uv (provides uvx for MCP servers)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+# Install Node.js 24 from the official image instead of the distro's apt package
+# (Debian ships Node 20, but @esaio/esa-mcp-server requires node >=24 and was
+# unstable on Node 20 — heavy esa queries hung on EC2). Copy the binaries and
+# the npm/npx module tree, then recreate the bin symlinks.
+COPY --from=node:24-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:24-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 WORKDIR /app
 
 # Install dependencies
 COPY pyproject.toml .
 RUN uv pip install --system .
-RUN apt update && apt install -y nodejs npm
 
 # Copy application
 COPY main.py .

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LangGraph で実装した Slack 向けエージェント。ユーザーの入力
 - **MCP ツール連携** — `mcp_config.json` に定義した stdio MCP サーバーのツールを LangGraph のツールとして自動ロードする。
 - **ツール結果の圧縮とキャッシュ** — 大きなツール結果は軽量モデルで要約し、生の結果はキャッシュに退避する。後続のやり取りでは `cache_fetcher` ツールで生の結果を取り出せる。
 - **スレッド単位の会話履歴** — Slack の `thread_ts` を LangGraph の `thread_id` として扱い、checkpointer で会話履歴を永続化する。
-- **進捗メッセージ** — ツール実行前に思考とツール呼び出しを Slack スレッドへ逐次通知する。
+- **進捗表示** — ツール実行を Slack の Plan Block（`chat.startStream` ベースの構造化タスク表示）で逐次通知する。Plan Block 非対応の環境では自動でテキスト表示にフォールバックする。
 - **リトライ** — ツール呼び出し・LLM 呼び出しを指数バックオフでリトライする（5xx はリトライ、4xx はリトライしない）。
 
 ## アーキテクチャ
@@ -79,7 +79,7 @@ uv sync --extra ollama      # Ollama
   },
   "retry": { "max_attempts": 3, "backoff_base_seconds": 1.0 },
   "cache": { "ttl_hours": 6 },
-  "agent": { "compression_threshold_bytes": 10000, "recursion_limit": 25 },
+  "agent": { "compression_threshold_bytes": 10000, "recursion_limit": 25, "progress_mode": "auto" },
   "storage": { "type": "memory" }
 }
 ```
@@ -94,6 +94,7 @@ uv sync --extra ollama      # Ollama
 | `cache.ttl_hours` | キャッシュエントリの有効期限（時間） |
 | `agent.compression_threshold_bytes` | ToolMessage を圧縮する閾値（バイト） |
 | `agent.recursion_limit` | LangGraph の再帰上限 |
+| `agent.progress_mode` | 進捗表示モード。`auto`（Plan Block を試し失敗で text にフォールバック）/ `plan` / `text` |
 | `storage.type` | checkpointer のバックエンド。現状は `memory` のみ対応 |
 
 ### `mcp_config.json`

--- a/main.py
+++ b/main.py
@@ -67,7 +67,10 @@ async def main():
 
     cache_store = InMemoryCacheStore()
 
-    mcp_tools = await load_mcp_tools(args.mcp_config)
+    mcp_tools = await load_mcp_tools(
+        args.mcp_config,
+        tool_timeout_seconds=config.agent.mcp_tool_timeout_seconds,
+    )
     cache_fetcher = make_cache_fetcher_tool(cache_store)
     all_tools = mcp_tools + [cache_fetcher]
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+from contextlib import AsyncExitStack
 from pathlib import Path
 
 from slack_agent.cache import InMemoryCacheStore
@@ -11,7 +12,7 @@ from slack_agent.checkpointer import create_checkpointer
 from slack_agent.config import build_llm, load_config, _expand_recursive
 from slack_agent.graph import build_graph
 from slack_agent.slack_handler import create_app, run_app
-from slack_agent.tools import load_mcp_tools, make_cache_fetcher_tool, _load_server_tools
+from slack_agent.tools import load_mcp_tools, make_cache_fetcher_tool, _connect_server
 
 # DEBUG_LLM=1 で LangChain の verbose/debug を有効にし、LLM への入出力を全部出す
 if os.environ.get("DEBUG_LLM"):
@@ -35,9 +36,11 @@ async def dry_run(mcp_config_path: str):
     for server_name, server_cfg in servers.items():
         print(f"[{server_name}] connecting... ", end="", flush=True)
         try:
-            tools = await _load_server_tools(server_name, server_cfg)
-            tool_names = ", ".join(t.name for t in tools)
-            print(f"OK ({len(tools)} tools: {tool_names})")
+            # 接続確認のみ。確認後すぐにセッションを閉じる。
+            async with AsyncExitStack() as stack:
+                tools = await _connect_server(server_name, server_cfg, None, stack)
+                tool_names = ", ".join(t.name for t in tools)
+                print(f"OK ({len(tools)} tools: {tool_names})")
             ok.append(server_name)
         except Exception as exc:
             print(f"FAILED: {exc}")
@@ -67,41 +70,45 @@ async def main():
 
     cache_store = InMemoryCacheStore()
 
-    mcp_tools = await load_mcp_tools(
-        args.mcp_config,
-        tool_timeout_seconds=config.agent.mcp_tool_timeout_seconds,
-    )
-    cache_fetcher = make_cache_fetcher_tool(cache_store)
-    all_tools = mcp_tools + [cache_fetcher]
+    # MCP セッションはアプリ稼働中ずっと保持する。run_app まで同じ
+    # AsyncExitStack 内で動かし、終了時にまとめてクローズする。
+    async with AsyncExitStack() as mcp_stack:
+        mcp_tools = await load_mcp_tools(
+            args.mcp_config,
+            tool_timeout_seconds=config.agent.mcp_tool_timeout_seconds,
+            exit_stack=mcp_stack,
+        )
+        cache_fetcher = make_cache_fetcher_tool(cache_store)
+        all_tools = mcp_tools + [cache_fetcher]
 
-    # Bind tools to the standard LLM for orchestrator
-    standard_llm = standard_llm.bind_tools(all_tools)
+        # Bind tools to the standard LLM for orchestrator
+        standard_llm = standard_llm.bind_tools(all_tools)
 
-    tools_by_name = {t.name: t for t in all_tools}
+        tools_by_name = {t.name: t for t in all_tools}
 
-    extra_prompt = ""
-    prompt_path = Path("prompt.md")
-    if prompt_path.exists():
-        extra_prompt = prompt_path.read_text()
-        logger.info("Loaded prompt.md as initial prompt")
+        extra_prompt = ""
+        prompt_path = Path("prompt.md")
+        if prompt_path.exists():
+            extra_prompt = prompt_path.read_text()
+            logger.info("Loaded prompt.md as initial prompt")
 
-    checkpointer = create_checkpointer(config.storage)
-    logger.info("Checkpointer initialized: type=%s", config.storage.type)
+        checkpointer = create_checkpointer(config.storage)
+        logger.info("Checkpointer initialized: type=%s", config.storage.type)
 
-    compiled_graph = build_graph(
-        config=config,
-        standard_llm=standard_llm,
-        light_llm=light_llm,
-        tools_by_name=tools_by_name,
-        cache_store=cache_store,
-        extra_prompt=extra_prompt,
-        checkpointer=checkpointer,
-    )
+        compiled_graph = build_graph(
+            config=config,
+            standard_llm=standard_llm,
+            light_llm=light_llm,
+            tools_by_name=tools_by_name,
+            cache_store=cache_store,
+            extra_prompt=extra_prompt,
+            checkpointer=checkpointer,
+        )
 
-    app = create_app(config, compiled_graph, config.agent)
+        app = create_app(config, compiled_graph, config.agent)
 
-    logger.info("Starting Slack MCP Agent...")
-    await run_app(config, app)
+        logger.info("Starting Slack MCP Agent...")
+        await run_app(config, app)
 
 
 if __name__ == "__main__":

--- a/settings.json
+++ b/settings.json
@@ -19,7 +19,8 @@
   },
   "agent": {
     "compression_threshold_bytes": 10000,
-    "recursion_limit": 25
+    "recursion_limit": 25,
+    "progress_mode": "auto"
   },
   "storage": {
     "type": "memory"

--- a/settings.json
+++ b/settings.json
@@ -20,7 +20,8 @@
   "agent": {
     "compression_threshold_bytes": 10000,
     "recursion_limit": 25,
-    "progress_mode": "auto"
+    "progress_mode": "auto",
+    "mcp_tool_timeout_seconds": 60
   },
   "storage": {
     "type": "memory"

--- a/slack_agent/config.py
+++ b/slack_agent/config.py
@@ -61,6 +61,9 @@ class AgentConfig:
     recursion_limit: int
     # 進捗表示モード: "auto" (Plan Block を試し失敗で text) / "plan" / "text"
     progress_mode: str
+    # MCP ツール呼び出しの応答待ちタイムアウト秒。応答が無い MCP サーバーで
+    # 無限ハングするのを防ぐ。
+    mcp_tool_timeout_seconds: float
 
 
 @dataclass
@@ -114,6 +117,7 @@ def load_config(settings_path: str = "settings.json") -> AppConfig:
         compression_threshold_bytes=agent_raw.get("compression_threshold_bytes", 10000),
         recursion_limit=agent_raw.get("recursion_limit", 25),
         progress_mode=agent_raw.get("progress_mode", "auto"),
+        mcp_tool_timeout_seconds=agent_raw.get("mcp_tool_timeout_seconds", 60.0),
     )
 
     storage_raw = raw.get("storage", {"type": "memory"})

--- a/slack_agent/config.py
+++ b/slack_agent/config.py
@@ -59,6 +59,8 @@ class CacheConfig:
 class AgentConfig:
     compression_threshold_bytes: int
     recursion_limit: int
+    # 進捗表示モード: "auto" (Plan Block を試し失敗で text) / "plan" / "text"
+    progress_mode: str
 
 
 @dataclass
@@ -111,6 +113,7 @@ def load_config(settings_path: str = "settings.json") -> AppConfig:
     agent = AgentConfig(
         compression_threshold_bytes=agent_raw.get("compression_threshold_bytes", 10000),
         recursion_limit=agent_raw.get("recursion_limit", 25),
+        progress_mode=agent_raw.get("progress_mode", "auto"),
     )
 
     storage_raw = raw.get("storage", {"type": "memory"})

--- a/slack_agent/graph.py
+++ b/slack_agent/graph.py
@@ -50,8 +50,8 @@ def build_graph(
     async def tool_executor(state: AgentState) -> dict:
         from langgraph.config import get_config
         rconfig = get_config()
-        slack_notify = rconfig.get("configurable", {}).get("slack_notify")
-        return await tool_executor_node(state, tools_by_name, slack_notify, config.retry)
+        progress_reporter = rconfig.get("configurable", {}).get("progress_reporter")
+        return await tool_executor_node(state, tools_by_name, progress_reporter, config.retry)
 
     async def compressor(state: AgentState) -> dict:
         return await compressor_node(

--- a/slack_agent/nodes.py
+++ b/slack_agent/nodes.py
@@ -158,6 +158,8 @@ async def tool_executor_node(
                 )
             continue
 
+        logger.info("Tool call start: tool=%s args=%r", tool_name, tool_args)
+
         async def _run_tool():
             return await tool_instance.ainvoke(tool_args)
 
@@ -178,6 +180,7 @@ async def tool_executor_node(
                 max_attempts=retry_config.max_attempts,
                 backoff_base=retry_config.backoff_base_seconds,
             )
+            logger.info("Tool call done: tool=%s result_size=%dB", tool_name, len(str(result).encode()))
             tool_messages.append(
                 ToolMessage(
                     content=str(result),

--- a/slack_agent/nodes.py
+++ b/slack_agent/nodes.py
@@ -74,29 +74,6 @@ def _build_orchestrator_system(cache_references: list[CacheReference], extra_pro
     return prompt
 
 
-def _build_pending_message(response: AIMessage) -> str | None:
-    if not response.tool_calls:
-        return None
-    lines = []
-    # AIMessageのテキスト部分（思考・説明）があれば先に追加
-    content = response.content
-    def _quote(text: str) -> str:
-        return "\n".join(f"> _{line}_" for line in text.strip().splitlines())
-
-    if isinstance(content, str) and content.strip():
-        lines.append(_quote(content))
-    elif isinstance(content, list):
-        # content blocksの場合（anthropicなど）
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text" and block.get("text", "").strip():
-                lines.append(_quote(block["text"]))
-    # tool calls
-    for tc in response.tool_calls:
-        args_str = json.dumps(tc.get("args", {}), ensure_ascii=False)
-        lines.append(f"> _{tc['name']} {args_str}_")
-    return "\n".join(lines)
-
-
 async def orchestrator_node(
     state: AgentState,
     standard_llm: BaseChatModel,
@@ -129,30 +106,41 @@ async def orchestrator_node(
 
     return {
         "messages": [response],
-        "pending_progress_message": _build_pending_message(response),
     }
+
+
+def _task_title(tool_name: str, tool_args: dict) -> str:
+    """進捗タスクのタイトル。ツール名と引数を 1 行で表す。"""
+    args_str = json.dumps(tool_args, ensure_ascii=False)
+    return f"{tool_name} {args_str}"
 
 
 async def tool_executor_node(
     state: AgentState,
     tools_by_name: dict,
-    slack_notify_func,
+    progress_reporter,
     retry_config,
 ) -> dict:
+    from .progress import STATUS_COMPLETE, STATUS_IN_PROGRESS
+
     last_message = state["messages"][-1]
     if not isinstance(last_message, AIMessage) or not last_message.tool_calls:
         return {}
-
-    # Send progress to Slack before executing tools
-    pending = state.get("pending_progress_message")
-    if pending and slack_notify_func:
-        await slack_notify_func(pending)
 
     tool_messages = []
     for tool_call in last_message.tool_calls:
         tool_name = tool_call["name"]
         tool_args = tool_call["args"]
         tool_call_id = tool_call["id"]
+
+        # tool_call 1 件を 1 タスクとして進捗表示する (Issue #6)。
+        # task_id には tool_call_id を使う。
+        if progress_reporter:
+            await progress_reporter.update_task(
+                tool_call_id,
+                title=_task_title(tool_name, tool_args),
+                status=STATUS_IN_PROGRESS,
+            )
 
         tool_instance = tools_by_name.get(tool_name)
         if tool_instance is None:
@@ -162,6 +150,12 @@ async def tool_executor_node(
                     tool_call_id=tool_call_id,
                 )
             )
+            if progress_reporter:
+                await progress_reporter.update_task(
+                    tool_call_id,
+                    status=STATUS_COMPLETE,
+                    output=f"Tool '{tool_name}' not found.",
+                )
             continue
 
         async def _run_tool():
@@ -191,6 +185,10 @@ async def tool_executor_node(
                     additional_kwargs=cache_meta,
                 )
             )
+            if progress_reporter:
+                await progress_reporter.update_task(
+                    tool_call_id, status=STATUS_COMPLETE
+                )
         except Exception as exc:
             logger.error("Tool '%s' failed after retries: %s", tool_name, exc)
             tool_messages.append(
@@ -199,10 +197,15 @@ async def tool_executor_node(
                     tool_call_id=tool_call_id,
                 )
             )
+            if progress_reporter:
+                await progress_reporter.update_task(
+                    tool_call_id,
+                    status=STATUS_COMPLETE,
+                    output=f"failed: {exc}",
+                )
 
     return {
         "messages": tool_messages,
-        "pending_progress_message": None,
     }
 
 

--- a/slack_agent/progress.py
+++ b/slack_agent/progress.py
@@ -54,22 +54,40 @@ class ProgressReporter(ABC):
 
 
 class PlanBlockReporter(ProgressReporter):
-    """Plan Block を chat.startStream / chat.appendStream で送る reporter。"""
+    """Plan Block を chat.startStream / chat.appendStream で送る reporter。
 
-    def __init__(self, client, channel: str, thread_ts: str):
+    chat.startStream は recipient_team_id が必須 (無いと missing_recipient_team_id)。
+    DM など 1:1 の文脈では recipient_user_id も渡す。
+    """
+
+    def __init__(
+        self,
+        client,
+        channel: str,
+        thread_ts: str,
+        recipient_team_id: str | None = None,
+        recipient_user_id: str | None = None,
+    ):
         self._client = client
         self._channel = channel
         self._thread_ts = thread_ts
+        self._recipient_team_id = recipient_team_id
+        self._recipient_user_id = recipient_user_id
         self._stream_ts: str | None = None
         # task_id -> title を保持し、status 更新時に title を再送できるようにする
         self._titles: dict[str, str] = {}
 
     async def start(self) -> None:
-        result = await self._client.chat_startStream(
-            channel=self._channel,
-            thread_ts=self._thread_ts,
-            task_display_mode="plan",
-        )
+        kwargs: dict = {
+            "channel": self._channel,
+            "thread_ts": self._thread_ts,
+            "task_display_mode": "plan",
+        }
+        if self._recipient_team_id is not None:
+            kwargs["recipient_team_id"] = self._recipient_team_id
+        if self._recipient_user_id is not None:
+            kwargs["recipient_user_id"] = self._recipient_user_id
+        result = await self._client.chat_startStream(**kwargs)
         self._stream_ts = result["ts"]
 
     async def update_task(
@@ -187,11 +205,21 @@ class LazyReporter(ProgressReporter):
     tool_call が無く即答するケースで空のストリーム/メッセージを作らないため。
     """
 
-    def __init__(self, client, channel: str, thread_ts: str, mode: str = "auto"):
+    def __init__(
+        self,
+        client,
+        channel: str,
+        thread_ts: str,
+        mode: str = "auto",
+        recipient_team_id: str | None = None,
+        recipient_user_id: str | None = None,
+    ):
         self._client = client
         self._channel = channel
         self._thread_ts = thread_ts
         self._mode = mode
+        self._recipient_team_id = recipient_team_id
+        self._recipient_user_id = recipient_user_id
         self._inner: ProgressReporter | None = None
 
     async def start(self) -> None:
@@ -207,7 +235,12 @@ class LazyReporter(ProgressReporter):
     ) -> None:
         if self._inner is None:
             self._inner = await create_reporter(
-                self._client, self._channel, self._thread_ts, self._mode
+                self._client,
+                self._channel,
+                self._thread_ts,
+                self._mode,
+                recipient_team_id=self._recipient_team_id,
+                recipient_user_id=self._recipient_user_id,
             )
         await self._inner.update_task(
             task_id, title=title, status=status, output=output
@@ -223,6 +256,8 @@ async def create_reporter(
     channel: str,
     thread_ts: str,
     mode: str = "auto",
+    recipient_team_id: str | None = None,
+    recipient_user_id: str | None = None,
 ) -> ProgressReporter:
     """mode に応じた reporter を生成する。
 
@@ -235,13 +270,20 @@ async def create_reporter(
         await reporter.start()
         return reporter
 
+    def _plan() -> PlanBlockReporter:
+        return PlanBlockReporter(
+            client, channel, thread_ts,
+            recipient_team_id=recipient_team_id,
+            recipient_user_id=recipient_user_id,
+        )
+
     if mode == "plan":
-        reporter = PlanBlockReporter(client, channel, thread_ts)
+        reporter = _plan()
         await reporter.start()
         return reporter
 
     # auto
-    plan = PlanBlockReporter(client, channel, thread_ts)
+    plan = _plan()
     try:
         await plan.start()
         return plan

--- a/slack_agent/progress.py
+++ b/slack_agent/progress.py
@@ -1,0 +1,252 @@
+"""Slack への進捗表示を抽象化するモジュール (Issue #6)。
+
+進捗を「タスクの集合とその状態遷移」として表現し、2 つの送信実装を提供する:
+
+- PlanBlockReporter: Slack の Plan Block (chat.startStream / chat.appendStream)
+  を使い、tool_call を 1 タスクとして構造化表示する。AI agent 機能が有効で
+  assistant:write スコープを持つワークスペースでのみ動作する。
+- TextProgressReporter: chat_postMessage / chat_update で 1 メッセージを
+  更新し続ける従来のテキスト blockquote 表示。Plan Block 非対応環境向け。
+
+create_reporter(...) は mode="auto" の場合に Plan Block を試み、開始に失敗
+したら Text にフォールバックする。
+"""
+
+import logging
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+# Slack Plan Block の task status 値
+STATUS_PENDING = "pending"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_COMPLETE = "complete"
+
+
+class ProgressReporter(ABC):
+    """進捗表示の抽象基底。
+
+    使い方:
+        await reporter.start()
+        await reporter.update_task("task_1", title="...", status=STATUS_IN_PROGRESS)
+        await reporter.update_task("task_1", status=STATUS_COMPLETE, output="...")
+        await reporter.finish()
+    """
+
+    @abstractmethod
+    async def start(self) -> None:
+        ...
+
+    @abstractmethod
+    async def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        status: str = STATUS_IN_PROGRESS,
+        output: str | None = None,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    async def finish(self) -> None:
+        ...
+
+
+class PlanBlockReporter(ProgressReporter):
+    """Plan Block を chat.startStream / chat.appendStream で送る reporter。"""
+
+    def __init__(self, client, channel: str, thread_ts: str):
+        self._client = client
+        self._channel = channel
+        self._thread_ts = thread_ts
+        self._stream_ts: str | None = None
+        # task_id -> title を保持し、status 更新時に title を再送できるようにする
+        self._titles: dict[str, str] = {}
+
+    async def start(self) -> None:
+        result = await self._client.chat_startStream(
+            channel=self._channel,
+            thread_ts=self._thread_ts,
+            task_display_mode="plan",
+        )
+        self._stream_ts = result["ts"]
+
+    async def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        status: str = STATUS_IN_PROGRESS,
+        output: str | None = None,
+    ) -> None:
+        if title is not None:
+            self._titles[task_id] = title
+        chunk = {
+            "type": "task",
+            "id": task_id,
+            "text": self._titles.get(task_id, task_id),
+            "status": status,
+        }
+        if output is not None:
+            chunk["output"] = output
+        await self._client.chat_appendStream(
+            channel=self._channel,
+            ts=self._stream_ts,
+            chunks=[chunk],
+        )
+
+    async def finish(self) -> None:
+        if self._stream_ts is None:
+            return
+        await self._client.chat_stopStream(
+            channel=self._channel,
+            ts=self._stream_ts,
+        )
+
+
+class TextProgressReporter(ProgressReporter):
+    """テキスト blockquote を 1 メッセージで更新し続ける従来表示。
+
+    タスクごとに 1 行を持ち、status 変化のたびにメッセージ全体を再構築して
+    chat_update する。
+    """
+
+    _STATUS_ICON = {
+        STATUS_PENDING: "◻️",
+        STATUS_IN_PROGRESS: "⏳",
+        STATUS_COMPLETE: "✅",
+    }
+
+    def __init__(self, client, channel: str, thread_ts: str):
+        self._client = client
+        self._channel = channel
+        self._thread_ts = thread_ts
+        self._message_ts: str | None = None
+        # 表示順を保つため task_id のリストと内容を別管理
+        self._order: list[str] = []
+        self._tasks: dict[str, dict] = {}
+
+    async def start(self) -> None:
+        # 最初の update_task まで実際の投稿は遅延させる (空メッセージを作らない)
+        return None
+
+    def _render(self) -> str:
+        lines = []
+        for task_id in self._order:
+            task = self._tasks[task_id]
+            icon = self._STATUS_ICON.get(task["status"], "•")
+            text = task.get("title") or task_id
+            lines.append(f"> {icon} _{text}_")
+            output = task.get("output")
+            if output:
+                lines.append(f"> {output}")
+        return "\n".join(lines)
+
+    async def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        status: str = STATUS_IN_PROGRESS,
+        output: str | None = None,
+    ) -> None:
+        if task_id not in self._tasks:
+            self._order.append(task_id)
+            self._tasks[task_id] = {}
+        task = self._tasks[task_id]
+        if title is not None:
+            task["title"] = title
+        task["status"] = status
+        if output is not None:
+            task["output"] = output
+
+        combined = self._render()
+        if self._message_ts is None:
+            result = await self._client.chat_postMessage(
+                channel=self._channel,
+                thread_ts=self._thread_ts,
+                text=combined,
+            )
+            self._message_ts = result["ts"]
+        else:
+            await self._client.chat_update(
+                channel=self._channel,
+                ts=self._message_ts,
+                text=combined,
+            )
+
+    async def finish(self) -> None:
+        # テキストモードでは特に終了処理は不要
+        return None
+
+
+class LazyReporter(ProgressReporter):
+    """初回の update_task まで実際の reporter 生成 (= Slack 投稿) を遅延する。
+
+    tool_call が無く即答するケースで空のストリーム/メッセージを作らないため。
+    """
+
+    def __init__(self, client, channel: str, thread_ts: str, mode: str = "auto"):
+        self._client = client
+        self._channel = channel
+        self._thread_ts = thread_ts
+        self._mode = mode
+        self._inner: ProgressReporter | None = None
+
+    async def start(self) -> None:
+        return None
+
+    async def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        status: str = STATUS_IN_PROGRESS,
+        output: str | None = None,
+    ) -> None:
+        if self._inner is None:
+            self._inner = await create_reporter(
+                self._client, self._channel, self._thread_ts, self._mode
+            )
+        await self._inner.update_task(
+            task_id, title=title, status=status, output=output
+        )
+
+    async def finish(self) -> None:
+        if self._inner is not None:
+            await self._inner.finish()
+
+
+async def create_reporter(
+    client,
+    channel: str,
+    thread_ts: str,
+    mode: str = "auto",
+) -> ProgressReporter:
+    """mode に応じた reporter を生成する。
+
+    - "plan": PlanBlockReporter を使う (失敗してもフォールバックしない)
+    - "text": TextProgressReporter を使う
+    - "auto": Plan Block を試し、start に失敗したら Text にフォールバック
+    """
+    if mode == "text":
+        reporter: ProgressReporter = TextProgressReporter(client, channel, thread_ts)
+        await reporter.start()
+        return reporter
+
+    if mode == "plan":
+        reporter = PlanBlockReporter(client, channel, thread_ts)
+        await reporter.start()
+        return reporter
+
+    # auto
+    plan = PlanBlockReporter(client, channel, thread_ts)
+    try:
+        await plan.start()
+        return plan
+    except Exception as exc:
+        logger.info("Plan Block unavailable, falling back to text progress: %s", exc)
+        text = TextProgressReporter(client, channel, thread_ts)
+        await text.start()
+        return text

--- a/slack_agent/progress.py
+++ b/slack_agent/progress.py
@@ -21,6 +21,18 @@ logger = logging.getLogger(__name__)
 STATUS_PENDING = "pending"
 STATUS_IN_PROGRESS = "in_progress"
 STATUS_COMPLETE = "complete"
+STATUS_ERROR = "error"
+
+# task_update chunk の title / output は 256 文字制限がある
+_PLAN_TEXT_LIMIT = 256
+
+
+def _truncate(text: str | None) -> str | None:
+    if text is None:
+        return None
+    if len(text) <= _PLAN_TEXT_LIMIT:
+        return text
+    return text[: _PLAN_TEXT_LIMIT - 1] + "…"
 
 
 class ProgressReporter(ABC):
@@ -100,14 +112,17 @@ class PlanBlockReporter(ProgressReporter):
     ) -> None:
         if title is not None:
             self._titles[task_id] = title
-        chunk = {
-            "type": "task",
+        # chat.appendStream の task chunk スキーマ:
+        #   type="task_update", id, title, status, (details/output/sources)
+        # title/output は 256 文字制限。
+        chunk: dict = {
+            "type": "task_update",
             "id": task_id,
-            "text": self._titles.get(task_id, task_id),
+            "title": _truncate(self._titles.get(task_id, task_id)),
             "status": status,
         }
         if output is not None:
-            chunk["output"] = output
+            chunk["output"] = _truncate(output)
         await self._client.chat_appendStream(
             channel=self._channel,
             ts=self._stream_ts,
@@ -233,22 +248,30 @@ class LazyReporter(ProgressReporter):
         status: str = STATUS_IN_PROGRESS,
         output: str | None = None,
     ) -> None:
-        if self._inner is None:
-            self._inner = await create_reporter(
-                self._client,
-                self._channel,
-                self._thread_ts,
-                self._mode,
-                recipient_team_id=self._recipient_team_id,
-                recipient_user_id=self._recipient_user_id,
+        # 進捗表示はベストエフォート。Slack 側のスキーマ/権限エラーで
+        # エージェント本体の処理を止めない。
+        try:
+            if self._inner is None:
+                self._inner = await create_reporter(
+                    self._client,
+                    self._channel,
+                    self._thread_ts,
+                    self._mode,
+                    recipient_team_id=self._recipient_team_id,
+                    recipient_user_id=self._recipient_user_id,
+                )
+            await self._inner.update_task(
+                task_id, title=title, status=status, output=output
             )
-        await self._inner.update_task(
-            task_id, title=title, status=status, output=output
-        )
+        except Exception as exc:
+            logger.warning("Progress update failed (ignored): %s", exc)
 
     async def finish(self) -> None:
         if self._inner is not None:
-            await self._inner.finish()
+            try:
+                await self._inner.finish()
+            except Exception as exc:
+                logger.warning("Progress finish failed (ignored): %s", exc)
 
 
 async def create_reporter(

--- a/slack_agent/retry.py
+++ b/slack_agent/retry.py
@@ -9,12 +9,21 @@ T = TypeVar("T")
 # HTTP status codes that should not be retried
 _NO_RETRY_STATUS_CODES = frozenset(range(400, 500))
 
+# リトライしても無駄なタイムアウト系の例外クラス名。
+# MCP ツールの応答待ちタイムアウト (McpError "Timed out ... Waited N seconds") は
+# 同じ呼び出しを再試行しても同じ時間待たされるだけで、サーバ側が無応答な限り
+# 成功しない。リトライ対象外にしてロック占有と待ち時間を減らす。
+_NO_RETRY_EXC_NAMES = frozenset({"McpError", "TimeoutError"})
+
 
 def _should_retry_exception(exc: Exception) -> bool:
     """Return True if the exception is retryable."""
     # Check for HTTP status in exception attributes (httpx, aiohttp, requests style)
     status_code = getattr(exc, "status_code", None) or getattr(exc, "status", None)
     if status_code is not None and status_code in _NO_RETRY_STATUS_CODES:
+        return False
+    # タイムアウト系は再試行しても無駄なので即座に失敗させる。
+    if type(exc).__name__ in _NO_RETRY_EXC_NAMES:
         return False
     return True
 

--- a/slack_agent/retry.py
+++ b/slack_agent/retry.py
@@ -19,6 +19,17 @@ def _should_retry_exception(exc: Exception) -> bool:
     return True
 
 
+def _describe_exception(exc: BaseException) -> str:
+    """例外を説明する文字列。ExceptionGroup (TaskGroup 例外) は
+    sub-exception を再帰的に展開して中身を見えるようにする。
+    """
+    group = getattr(exc, "exceptions", None)
+    if group is not None:
+        inner = "; ".join(_describe_exception(e) for e in group)
+        return f"{type(exc).__name__}[{inner}]"
+    return f"{type(exc).__name__}: {exc}"
+
+
 async def retry_async(
     func: Callable,
     *args,
@@ -33,15 +44,19 @@ async def retry_async(
             return await func(*args, **kwargs)
         except Exception as exc:
             last_exc = exc
+            desc = _describe_exception(exc)
             if not _should_retry_exception(exc):
-                logger.warning("Non-retryable error (attempt %d/%d): %s", attempt, max_attempts, exc)
+                logger.warning("Non-retryable error (attempt %d/%d): %s", attempt, max_attempts, desc)
                 raise
             if attempt == max_attempts:
                 break
             wait = backoff_base * (2 ** (attempt - 1))
             logger.warning(
                 "Retryable error (attempt %d/%d), retrying in %.1fs: %s",
-                attempt, max_attempts, wait, exc,
+                attempt, max_attempts, wait, desc,
             )
             await asyncio.sleep(wait)
+    logger.error(
+        "All %d attempts failed: %s", max_attempts, _describe_exception(last_exc)
+    )
     raise last_exc

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -146,7 +146,8 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
 
         # 進捗表示: Plan Block (対応環境) またはテキストにフォールバック (Issue #6)。
         # 初回タスクまで実際の投稿は遅延される。
-        # chat.startStream は recipient_team_id が必須なので event/body から取得する。
+        # chat.startStream はチャンネルへのストリーミングで recipient_team_id と
+        # recipient_user_id が両方必須。event/body から取得する。
         team_id = body.get("team_id") or event.get("team")
         progress_reporter = LazyReporter(
             client,
@@ -154,6 +155,7 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             thread_ts,
             mode=agent_config.progress_mode,
             recipient_team_id=team_id,
+            recipient_user_id=user_id,
         )
 
         current_human = HumanMessage(content=text)

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -7,6 +7,7 @@ from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
 from .config import AppConfig
+from .progress import LazyReporter
 from .state import AgentState
 from .thread_history import fetch_new_replies
 
@@ -143,26 +144,11 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
         for i, m in enumerate(new_replies):
             logger.info("  new_replies[%d]: %r", i, str(m.content)[:80])
 
-        # 進捗メッセージ: 1件のみ投稿し、推論ステップを追記しながら更新
-        progress_ts: list[str] = []
-        progress_lines: list[str] = []
-
-        async def slack_notify(message: str):
-            progress_lines.append(message)
-            combined = "\n".join(progress_lines)
-            if not progress_ts:
-                result = await client.chat_postMessage(
-                    channel=channel,
-                    thread_ts=thread_ts,
-                    text=combined,
-                )
-                progress_ts.append(result["ts"])
-            else:
-                await client.chat_update(
-                    channel=channel,
-                    ts=progress_ts[0],
-                    text=combined,
-                )
+        # 進捗表示: Plan Block (対応環境) またはテキストにフォールバック (Issue #6)。
+        # 初回タスクまで実際の投稿は遅延される。
+        progress_reporter = LazyReporter(
+            client, channel, thread_ts, mode=agent_config.progress_mode
+        )
 
         current_human = HumanMessage(content=text)
         # last_bot_response_ts は initial_state に含めない (既存値を維持)
@@ -170,7 +156,6 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             "messages": new_replies + [current_human],
             "compression_threshold": agent_config.compression_threshold_bytes,
             "cache_references": [],
-            "pending_progress_message": None,
         }
 
         try:
@@ -179,7 +164,7 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
                 config={
                     "recursion_limit": agent_config.recursion_limit,
                     "configurable": {
-                        "slack_notify": slack_notify,
+                        "progress_reporter": progress_reporter,
                         "thread_id": thread_ts,
                     },
                 },
@@ -189,6 +174,11 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
         except Exception as exc:
             logger.exception("Agent failed: %s", exc)
             answer = _ERROR_MESSAGE
+        finally:
+            try:
+                await progress_reporter.finish()
+            except Exception as exc:
+                logger.warning("Failed to finish progress reporter: %s", exc)
 
         # 最終回答は別メッセージとして投稿（進捗メッセージとは別スレッド返信）
         result = await client.chat_postMessage(

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -146,8 +146,14 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
 
         # 進捗表示: Plan Block (対応環境) またはテキストにフォールバック (Issue #6)。
         # 初回タスクまで実際の投稿は遅延される。
+        # chat.startStream は recipient_team_id が必須なので event/body から取得する。
+        team_id = body.get("team_id") or event.get("team")
         progress_reporter = LazyReporter(
-            client, channel, thread_ts, mode=agent_config.progress_mode
+            client,
+            channel,
+            thread_ts,
+            mode=agent_config.progress_mode,
+            recipient_team_id=team_id,
         )
 
         current_human = HumanMessage(content=text)

--- a/slack_agent/state.py
+++ b/slack_agent/state.py
@@ -19,6 +19,5 @@ class AgentState(TypedDict):
     messages: Annotated[list, add_messages]
     compression_threshold: int
     cache_references: list[CacheReference]
-    pending_progress_message: str | None
     # 最後に bot が postMessage した ts。次回起動時の差分取得 (oldest) に使う
     last_bot_response_ts: str | None

--- a/slack_agent/tools.py
+++ b/slack_agent/tools.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import logging
+from contextlib import AsyncExitStack
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -22,58 +24,82 @@ def _expand_env_vars_in_config(mcp_config: dict) -> dict:
 async def load_mcp_tools(
     mcp_config_path: str = "mcp_config.json",
     tool_timeout_seconds: float | None = None,
+    exit_stack: AsyncExitStack | None = None,
 ) -> list[BaseTool]:
     """Load tools from all configured MCP servers.
 
-    キャッシュ保存はツール実行レイヤー (tool_executor_node) と
-    compressor_node に集約しているため、ここでは cache_store を扱わない。
+    各 MCP サーバーへの接続は起動時に 1 回だけ確立し、その ClientSession を
+    保持して使い回す。ツール呼び出しごとにサーバーを起動し直すと再起動レースで
+    タイムアウトするため (Issue #6 調査)。
+
+    exit_stack: セッションのライフサイクルを管理する AsyncExitStack。
+        呼び出し元 (main) がアプリ終了まで開いたまま保持する。None の場合は
+        この関数内で開くが、その場合セッションはすぐ閉じられるため通常は渡すこと。
 
     tool_timeout_seconds: ツール呼び出しの応答待ちタイムアウト秒。None なら無制限。
+
+    キャッシュ保存はツール実行レイヤー (tool_executor_node) と
+    compressor_node に集約しているため、ここでは cache_store を扱わない。
     """
     raw = json.loads(Path(mcp_config_path).read_text())
     raw = _expand_env_vars_in_config(raw)
     servers: dict = raw.get("mcpServers", {})
 
+    if exit_stack is None:
+        exit_stack = AsyncExitStack()
+        await exit_stack.__aenter__()
+
     all_tools: list[BaseTool] = []
     for server_name, server_cfg in servers.items():
-        tools = await _load_server_tools(server_name, server_cfg, tool_timeout_seconds)
+        tools = await _connect_server(
+            server_name, server_cfg, tool_timeout_seconds, exit_stack
+        )
         all_tools.extend(tools)
 
     return all_tools
 
 
-async def _load_server_tools(
+async def _connect_server(
     server_name: str,
     server_cfg: dict,
-    tool_timeout_seconds: float | None = None,
+    tool_timeout_seconds: float | None,
+    exit_stack: AsyncExitStack,
 ) -> list[BaseTool]:
-    """Connect to a single stdio MCP server and return its tools as LangChain tools."""
+    """stdio MCP サーバーに接続し、保持したセッションを使う LangChain ツールを返す。
+
+    stdio_client と ClientSession を exit_stack に登録し、アプリ終了まで
+    セッションを生かしておく。"""
     command = server_cfg["command"]
     args = server_cfg.get("args", [])
     env = server_cfg.get("env", {})
 
     params = StdioServerParameters(command=command, args=args, env=env or None)
 
+    read, write = await exit_stack.enter_async_context(stdio_client(params))
+    session = await exit_stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+    # 同一セッションへの call_tool を直列化する (stdio ストリームへの並行アクセス回避)。
+    lock = asyncio.Lock()
+
+    result = await session.list_tools()
     tools: list[BaseTool] = []
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.list_tools()
-            for mcp_tool in result.tools:
-                lc_tool = _make_langchain_tool(
-                    server_name, mcp_tool, params, tool_timeout_seconds
-                )
-                tools.append(lc_tool)
+    for mcp_tool in result.tools:
+        lc_tool = _make_langchain_tool(
+            server_name, mcp_tool, session, lock, tool_timeout_seconds
+        )
+        tools.append(lc_tool)
+    logger.info("Connected to MCP server '%s' (%d tools)", server_name, len(tools))
     return tools
 
 
 def _make_langchain_tool(
     server_name: str,
     mcp_tool,
-    params: StdioServerParameters,
+    session: ClientSession,
+    lock: asyncio.Lock,
     tool_timeout_seconds: float | None = None,
 ) -> BaseTool:
-    """Wrap a single MCP tool as a LangChain BaseTool."""
+    """Wrap a single MCP tool as a LangChain BaseTool backed by a shared session."""
     tool_name = f"{server_name}__{mcp_tool.name}"
     tool_description = mcp_tool.description or ""
     input_schema = mcp_tool.inputSchema or {}
@@ -85,15 +111,14 @@ def _make_langchain_tool(
     )
 
     async def _arun(**kwargs: Any) -> str:
-        async with stdio_client(params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(
-                    mcp_tool.name,
-                    arguments=kwargs,
-                    read_timeout_seconds=read_timeout,
-                )
-                return str(result.content)
+        # 保持済みセッションを使い回す。毎回サーバーを起動し直さない。
+        async with lock:
+            result = await session.call_tool(
+                mcp_tool.name,
+                arguments=kwargs,
+                read_timeout_seconds=read_timeout,
+            )
+        return str(result.content)
 
     return StructuredTool(
         name=tool_name,

--- a/slack_agent/tools.py
+++ b/slack_agent/tools.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,11 +21,14 @@ def _expand_env_vars_in_config(mcp_config: dict) -> dict:
 
 async def load_mcp_tools(
     mcp_config_path: str = "mcp_config.json",
+    tool_timeout_seconds: float | None = None,
 ) -> list[BaseTool]:
     """Load tools from all configured MCP servers.
 
     キャッシュ保存はツール実行レイヤー (tool_executor_node) と
     compressor_node に集約しているため、ここでは cache_store を扱わない。
+
+    tool_timeout_seconds: ツール呼び出しの応答待ちタイムアウト秒。None なら無制限。
     """
     raw = json.loads(Path(mcp_config_path).read_text())
     raw = _expand_env_vars_in_config(raw)
@@ -32,13 +36,17 @@ async def load_mcp_tools(
 
     all_tools: list[BaseTool] = []
     for server_name, server_cfg in servers.items():
-        tools = await _load_server_tools(server_name, server_cfg)
+        tools = await _load_server_tools(server_name, server_cfg, tool_timeout_seconds)
         all_tools.extend(tools)
 
     return all_tools
 
 
-async def _load_server_tools(server_name: str, server_cfg: dict) -> list[BaseTool]:
+async def _load_server_tools(
+    server_name: str,
+    server_cfg: dict,
+    tool_timeout_seconds: float | None = None,
+) -> list[BaseTool]:
     """Connect to a single stdio MCP server and return its tools as LangChain tools."""
     command = server_cfg["command"]
     args = server_cfg.get("args", [])
@@ -52,22 +60,39 @@ async def _load_server_tools(server_name: str, server_cfg: dict) -> list[BaseToo
             await session.initialize()
             result = await session.list_tools()
             for mcp_tool in result.tools:
-                lc_tool = _make_langchain_tool(server_name, mcp_tool, params)
+                lc_tool = _make_langchain_tool(
+                    server_name, mcp_tool, params, tool_timeout_seconds
+                )
                 tools.append(lc_tool)
     return tools
 
 
-def _make_langchain_tool(server_name: str, mcp_tool, params: StdioServerParameters) -> BaseTool:
+def _make_langchain_tool(
+    server_name: str,
+    mcp_tool,
+    params: StdioServerParameters,
+    tool_timeout_seconds: float | None = None,
+) -> BaseTool:
     """Wrap a single MCP tool as a LangChain BaseTool."""
     tool_name = f"{server_name}__{mcp_tool.name}"
     tool_description = mcp_tool.description or ""
     input_schema = mcp_tool.inputSchema or {}
+    # 応答が返らない MCP サーバーで無限ハングしないよう read_timeout を渡す。
+    read_timeout = (
+        timedelta(seconds=tool_timeout_seconds)
+        if tool_timeout_seconds is not None
+        else None
+    )
 
     async def _arun(**kwargs: Any) -> str:
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                result = await session.call_tool(mcp_tool.name, arguments=kwargs)
+                result = await session.call_tool(
+                    mcp_tool.name,
+                    arguments=kwargs,
+                    read_timeout_seconds=read_timeout,
+                )
                 return str(result.content)
 
     return StructuredTool(

--- a/slack_agent/tools.py
+++ b/slack_agent/tools.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 from contextlib import AsyncExitStack
@@ -78,14 +77,12 @@ async def _connect_server(
     read, write = await exit_stack.enter_async_context(stdio_client(params))
     session = await exit_stack.enter_async_context(ClientSession(read, write))
     await session.initialize()
-    # 同一セッションへの call_tool を直列化する (stdio ストリームへの並行アクセス回避)。
-    lock = asyncio.Lock()
 
     result = await session.list_tools()
     tools: list[BaseTool] = []
     for mcp_tool in result.tools:
         lc_tool = _make_langchain_tool(
-            server_name, mcp_tool, session, lock, tool_timeout_seconds
+            server_name, mcp_tool, session, tool_timeout_seconds
         )
         tools.append(lc_tool)
     logger.info("Connected to MCP server '%s' (%d tools)", server_name, len(tools))
@@ -96,7 +93,6 @@ def _make_langchain_tool(
     server_name: str,
     mcp_tool,
     session: ClientSession,
-    lock: asyncio.Lock,
     tool_timeout_seconds: float | None = None,
 ) -> BaseTool:
     """Wrap a single MCP tool as a LangChain BaseTool backed by a shared session."""
@@ -112,12 +108,14 @@ def _make_langchain_tool(
 
     async def _arun(**kwargs: Any) -> str:
         # 保持済みセッションを使い回す。毎回サーバーを起動し直さない。
-        async with lock:
-            result = await session.call_tool(
-                mcp_tool.name,
-                arguments=kwargs,
-                read_timeout_seconds=read_timeout,
-            )
+        # call_tool は直列化しない: ClientSession は request_id ごとに応答 stream を
+        # 多重化するため並行呼び出しに対応している。直列化すると 1 本のハング
+        # (esa の重いクエリ等) が後続の全ツールを巻き添えにする (連鎖タイムアウト)。
+        result = await session.call_tool(
+            mcp_tool.name,
+            arguments=kwargs,
+            read_timeout_seconds=read_timeout,
+        )
         return str(result.content)
 
     return StructuredTool(

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ uv run --extra dev pytest tests/test_retry.py::test_retry_returns_on_success
 
 | ファイル | 件数 | 対象 | 主な検証内容 |
 |---|---|---|---|
-| `test_retry.py` | 9 | `slack_agent/retry.py` | リトライ成功 / transient 失敗からの回復 / max_attempts 到達で last 例外 / 4xx 非リトライ・5xx リトライ判定 / args・kwargs の透過 |
+| `test_retry.py` | 15 | `slack_agent/retry.py` | リトライ成功 / transient 失敗からの回復 / max_attempts 到達で last 例外 / 4xx 非リトライ・5xx リトライ判定 / McpError・TimeoutError の非リトライ（タイムアウトは即失敗）/ ExceptionGroup の展開 / args・kwargs の透過 |
 | `test_config.py` | 8 | `slack_agent/config.py` | `${VAR}` / `${VAR:-default}` / 未定義変数の展開 / ネスト構造の再帰展開 / 非文字列値の保持 / `load_config` のフルロードとデフォルト値 |
 | `test_thread_history.py` | 8 | `slack_agent/thread_history.py` | API 例外時の空リスト / diff・fallback モードの `oldest` 指定 / subtype・current_ts・空 text の除外 / diff 時のスレッドルート除外と fallback 時の取込 / メンション除去 / assistant メッセージの prefix 付与 |
 | `test_graph_routing.py` | 6 | `slack_agent/graph.py` の分岐関数 | `_should_compress` の閾値判定と直近 ToolMessage のみ参照する挙動 / `_after_orchestrator` の tool_calls 有無による分岐 |
@@ -30,9 +30,11 @@ uv run --extra dev pytest tests/test_retry.py::test_retry_returns_on_success
 | `test_cache_flow.py` | 6 | `slack_agent/nodes.py` (キャッシュフロー) | tool 実行時の決定的 `cache_key` 付与 / `cache_fetcher` 自身の除外 / compressor がメタ情報からキャッシュ保存・参照登録 / 閾値以下は非圧縮・非キャッシュ / 不正 JSON 時の元メッセージ保持 / 非 ToolMessage の素通り |
 | `test_graph_flow.py` | 8 | `slack_agent/graph.py` の `build_graph` 全体 | グラフ遷移の統合テスト（下記参照） |
 | `test_slack_handler.py` | 6 | `slack_agent/slack_handler.py` の `ThreadLockManager` | 同一 thread の直列化 / 別 thread の並行性 / 使用後の即時解放 / 待機者がいる間の保持 / 例外時の解放 / 未知 key の release 安全性 |
-| `test_progress.py` | 12 | `slack_agent/progress.py` | PlanBlockReporter の startStream/appendStream/stopStream とタスク status 遷移・output / TextProgressReporter の投稿→更新と複数タスクの順序 / create_reporter の auto フォールバック・mode 強制 / LazyReporter の遅延生成と空時 no-op |
+| `test_progress.py` | 16 | `slack_agent/progress.py` | PlanBlockReporter の startStream/appendStream/stopStream・task_update スキーマ・status 遷移・output・256字切り詰め・recipient_team_id/user_id 伝播 / TextProgressReporter の投稿→更新と複数タスクの順序 / create_reporter の auto フォールバック・mode 強制 / LazyReporter の遅延生成・空時 no-op・エラー握り潰し |
+| `test_tools.py` | 5 | `slack_agent/tools.py` | call_tool への read_timeout 伝播（timedelta / None）/ ツール名のサーバープレフィックス / 保持セッションの使い回し（再接続しない）/ 直列化しない（1 本のハングが後続を巻き添えにしない） |
+| `test_compressor.py` | 8 | `slack_agent/nodes.py`（compressor） | ToolMessage 圧縮・要約・content_index 抽出ほか |
 
-合計 82 テスト（`test_graph_flow.py` に reporter 連携の統合テストを 1 件追加）。
+合計 98 テスト。
 
 ## グラフ遷移の統合テスト (`test_graph_flow.py`)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,10 +28,11 @@ uv run --extra dev pytest tests/test_retry.py::test_retry_returns_on_success
 | `test_checkpointer.py` | 2 | `slack_agent/checkpointer.py` | `memory` → `MemorySaver` / 未知タイプで `ValueError` |
 | `test_cache_store.py` | 10 | `slack_agent/cache.py` | `make_key` の決定性・引数順非依存・ツール名/引数による差分・キー形式 / `is_expired` / `InMemoryCacheStore` の set-get・miss・期限切れエントリの退避 |
 | `test_cache_flow.py` | 6 | `slack_agent/nodes.py` (キャッシュフロー) | tool 実行時の決定的 `cache_key` 付与 / `cache_fetcher` 自身の除外 / compressor がメタ情報からキャッシュ保存・参照登録 / 閾値以下は非圧縮・非キャッシュ / 不正 JSON 時の元メッセージ保持 / 非 ToolMessage の素通り |
-| `test_graph_flow.py` | 7 | `slack_agent/graph.py` の `build_graph` 全体 | グラフ遷移の統合テスト（下記参照） |
+| `test_graph_flow.py` | 8 | `slack_agent/graph.py` の `build_graph` 全体 | グラフ遷移の統合テスト（下記参照） |
 | `test_slack_handler.py` | 6 | `slack_agent/slack_handler.py` の `ThreadLockManager` | 同一 thread の直列化 / 別 thread の並行性 / 使用後の即時解放 / 待機者がいる間の保持 / 例外時の解放 / 未知 key の release 安全性 |
+| `test_progress.py` | 12 | `slack_agent/progress.py` | PlanBlockReporter の startStream/appendStream/stopStream とタスク status 遷移・output / TextProgressReporter の投稿→更新と複数タスクの順序 / create_reporter の auto フォールバック・mode 強制 / LazyReporter の遅延生成と空時 no-op |
 
-合計 62 テスト。
+合計 82 テスト（`test_graph_flow.py` に reporter 連携の統合テストを 1 件追加）。
 
 ## グラフ遷移の統合テスト (`test_graph_flow.py`)
 
@@ -58,7 +59,7 @@ LangGraph には専用のテスト API は無く、`build_graph` で compile し
 - `_CompressorLLM`: compressor 用 light LLM。常に整形済み JSON を返す。
 - `_FakeTool`: 固定の結果文字列を返すツール。結果サイズを変えることで圧縮経路の有無を切り替える。
 
-> `tool_executor` ノードは `langgraph.config.get_config()` を呼ぶが、compiled graph 経由で実行すれば問題なく動く。`slack_notify` は未設定でも `None` になるだけ。
+> `tool_executor` ノードは `langgraph.config.get_config()` を呼ぶが、compiled graph 経由で実行すれば問題なく動く。`progress_reporter` は未設定でも `None` になるだけ。
 
 ## テスト追加時の指針
 

--- a/tests/test_cache_flow.py
+++ b/tests/test_cache_flow.py
@@ -48,7 +48,7 @@ def _ai_with_tool_call(name: str, args: dict, call_id: str) -> AIMessage:
 async def test_tool_executor_attaches_deterministic_cache_key():
     """tool 実行時に make_key と一致する cache_key が ToolMessage に付与される。"""
     ai = _ai_with_tool_call("srv__search", {"q": "hello"}, "tc1")
-    state = {"messages": [ai], "pending_progress_message": None}
+    state = {"messages": [ai]}
 
     out = await tool_executor_node(
         state, {"srv__search": _DummyTool(100)}, None, _RetryConfig()
@@ -65,7 +65,7 @@ async def test_tool_executor_attaches_deterministic_cache_key():
 async def test_cache_fetcher_result_is_not_cached():
     """cache_fetcher 自身の結果はキャッシュ対象外 (cache_key を付けない)。"""
     ai = _ai_with_tool_call("cache_fetcher", {"cache_key": "k"}, "tc2")
-    state = {"messages": [ai], "pending_progress_message": None}
+    state = {"messages": [ai]}
 
     out = await tool_executor_node(
         state, {"cache_fetcher": _DummyTool(100)}, None, _RetryConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,7 +74,12 @@ def test_load_config_full(tmp_path, monkeypatch):
         },
         "retry": {"max_attempts": 5, "backoff_base_seconds": 2.0},
         "cache": {"ttl_hours": 12},
-        "agent": {"compression_threshold_bytes": 5000, "recursion_limit": 30},
+        "agent": {
+            "compression_threshold_bytes": 5000,
+            "recursion_limit": 30,
+            "progress_mode": "plan",
+            "mcp_tool_timeout_seconds": 120,
+        },
         "storage": {"type": "memory"},
     }
     cfg = load_config(_write_settings(tmp_path, settings))
@@ -90,6 +95,8 @@ def test_load_config_full(tmp_path, monkeypatch):
     assert cfg.cache.ttl_hours == 12
     assert cfg.agent.compression_threshold_bytes == 5000
     assert cfg.agent.recursion_limit == 30
+    assert cfg.agent.progress_mode == "plan"
+    assert cfg.agent.mcp_tool_timeout_seconds == 120
     assert cfg.storage.type == "memory"
 
 
@@ -107,4 +114,6 @@ def test_load_config_applies_defaults(tmp_path):
     assert cfg.cache.ttl_hours == 6
     assert cfg.agent.compression_threshold_bytes == 10000
     assert cfg.agent.recursion_limit == 25
+    assert cfg.agent.progress_mode == "auto"
+    assert cfg.agent.mcp_tool_timeout_seconds == 60.0
     assert cfg.storage.type == "memory"

--- a/tests/test_graph_flow.py
+++ b/tests/test_graph_flow.py
@@ -67,7 +67,7 @@ def _config() -> AppConfig:
         light_model=ModelConfig(model="x:y", options={}),
         retry=RetryConfig(max_attempts=1, backoff_base_seconds=0),
         cache=CacheConfig(ttl_hours=6),
-        agent=AgentConfig(compression_threshold_bytes=10000, recursion_limit=25),
+        agent=AgentConfig(compression_threshold_bytes=10000, recursion_limit=25, progress_mode="auto"),
         storage=StorageConfig(type="memory"),
     )
 
@@ -81,7 +81,6 @@ def _initial_state(text: str) -> dict:
         "messages": [HumanMessage(content=text)],
         "compression_threshold": 10000,
         "cache_references": [],
-        "pending_progress_message": None,
     }
 
 
@@ -241,3 +240,43 @@ async def test_checkpointer_isolates_distinct_threads():
     b_contents = [str(m.content) for m in b["messages"]]
     assert "thread A msg" in a_contents and "thread B msg" not in a_contents
     assert "thread B msg" in b_contents and "thread A msg" not in b_contents
+
+
+class _RecordingReporter:
+    """progress_reporter のモック。update_task の呼び出しを記録する。"""
+
+    def __init__(self):
+        self.events: list[tuple] = []
+
+    async def update_task(self, task_id, *, title=None, status="in_progress", output=None):
+        self.events.append((task_id, title, status))
+
+    async def finish(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_progress_reporter_receives_task_transitions():
+    """configurable 経由で reporter が tool task の in_progress→complete を受け取る。"""
+    responses = [
+        _tool_call_ai("srv__search", {"q": "x"}, "tc1"),
+        AIMessage(content="done"),
+    ]
+    tools = {"srv__search": _FakeTool("small")}
+    graph = build_graph(_config(), _ScriptedLLM(responses), _CompressorLLM(), tools, InMemoryCacheStore())
+
+    reporter = _RecordingReporter()
+    await graph.ainvoke(
+        _initial_state("search x"),
+        config={"configurable": {"progress_reporter": reporter}},
+    )
+
+    # tc1 が in_progress → complete と遷移する
+    statuses = [(tid, st) for tid, _title, st in reporter.events]
+    assert ("tc1", "in_progress") in statuses
+    assert ("tc1", "complete") in statuses
+    # in_progress が complete より先
+    assert statuses.index(("tc1", "in_progress")) < statuses.index(("tc1", "complete"))
+    # in_progress 時に title が付く
+    in_progress = [e for e in reporter.events if e[2] == "in_progress"][0]
+    assert "srv__search" in in_progress[1]

--- a/tests/test_graph_flow.py
+++ b/tests/test_graph_flow.py
@@ -67,7 +67,7 @@ def _config() -> AppConfig:
         light_model=ModelConfig(model="x:y", options={}),
         retry=RetryConfig(max_attempts=1, backoff_base_seconds=0),
         cache=CacheConfig(ttl_hours=6),
-        agent=AgentConfig(compression_threshold_bytes=10000, recursion_limit=25, progress_mode="auto"),
+        agent=AgentConfig(compression_threshold_bytes=10000, recursion_limit=25, progress_mode="auto", mcp_tool_timeout_seconds=60),
         storage=StorageConfig(type="memory"),
     )
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -80,13 +80,21 @@ async def test_plan_block_passes_recipient_ids_when_given():
 
 
 @pytest.mark.asyncio
-async def test_create_reporter_auto_forwards_recipient_team_id():
-    """auto モードでも recipient_team_id が startStream に伝播する。"""
+async def test_create_reporter_auto_forwards_recipient_ids():
+    """auto モードでも recipient_team_id / recipient_user_id が startStream に伝播する。
+
+    チャンネルへのストリーミングでは両方が必須。
+    """
     client = _RecordingClient()
-    await create_reporter(client, "C1", "100", mode="auto", recipient_team_id="T999")
+    await create_reporter(
+        client, "C1", "100", mode="auto",
+        recipient_team_id="T999", recipient_user_id="U999",
+    )
 
     start_calls = [kwargs for kind, kwargs in client.calls if kind == "startStream"]
-    assert start_calls and start_calls[0]["recipient_team_id"] == "T999"
+    assert start_calls
+    assert start_calls[0]["recipient_team_id"] == "T999"
+    assert start_calls[0]["recipient_user_id"] == "U999"
 
 
 @pytest.mark.asyncio
@@ -205,6 +213,23 @@ async def test_lazy_reporter_defers_creation_until_first_task():
     await reporter.update_task("t1", title="x", status=STATUS_IN_PROGRESS)
     # 初回 update で startStream が走る
     assert client.kinds()[0] == "startStream"
+
+
+@pytest.mark.asyncio
+async def test_lazy_reporter_forwards_recipient_ids_to_plan_block():
+    """LazyReporter が recipient_team_id / recipient_user_id を startStream まで伝播する。"""
+    client = _RecordingClient()
+    reporter = LazyReporter(
+        client, "C1", "100", mode="auto",
+        recipient_team_id="T1", recipient_user_id="U1",
+    )
+    await reporter.start()
+    await reporter.update_task("t1", title="x", status=STATUS_IN_PROGRESS)
+
+    start_calls = [kwargs for kind, kwargs in client.calls if kind == "startStream"]
+    assert start_calls
+    assert start_calls[0]["recipient_team_id"] == "T1"
+    assert start_calls[0]["recipient_user_id"] == "U1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -111,14 +111,14 @@ async def test_plan_block_appends_task_chunks_and_status_transition():
 
     chunk1 = appends[0]["chunks"][0]
     assert chunk1 == {
-        "type": "task",
+        "type": "task_update",
         "id": "t1",
-        "text": "Search workspace",
+        "title": "Search workspace",
         "status": STATUS_IN_PROGRESS,
     }
     # status 更新時も title は保持される
     chunk2 = appends[1]["chunks"][0]
-    assert chunk2["text"] == "Search workspace"
+    assert chunk2["title"] == "Search workspace"
     assert chunk2["status"] == STATUS_COMPLETE
 
 
@@ -131,6 +131,20 @@ async def test_plan_block_includes_output_when_given():
 
     chunk = client.calls[-1][1]["chunks"][0]
     assert chunk["output"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_plan_block_truncates_long_title_and_output():
+    """title / output は 256 文字に切り詰められる。"""
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(client, "C1", "100")
+    await reporter.start()
+    long = "x" * 400
+    await reporter.update_task("t1", title=long, status=STATUS_COMPLETE, output=long)
+
+    chunk = client.calls[-1][1]["chunks"][0]
+    assert len(chunk["title"]) == 256
+    assert len(chunk["output"]) == 256
 
 
 @pytest.mark.asyncio
@@ -230,6 +244,33 @@ async def test_lazy_reporter_forwards_recipient_ids_to_plan_block():
     assert start_calls
     assert start_calls[0]["recipient_team_id"] == "T1"
     assert start_calls[0]["recipient_user_id"] == "U1"
+
+
+@pytest.mark.asyncio
+async def test_lazy_reporter_swallows_errors():
+    """進捗表示の失敗 (Slack エラー) は握りつぶし、本処理を止めない。"""
+
+    class _BrokenClient:
+        async def chat_startStream(self, **kwargs):
+            return {"ts": "stream-1"}
+
+        async def chat_appendStream(self, **kwargs):
+            raise RuntimeError("invalid_arguments")
+
+        async def chat_stopStream(self, **kwargs):
+            return {"ok": True}
+
+        async def chat_postMessage(self, **kwargs):
+            return {"ts": "m1"}
+
+        async def chat_update(self, **kwargs):
+            return {"ok": True}
+
+    reporter = LazyReporter(_BrokenClient(), "C1", "100", mode="plan")
+    await reporter.start()
+    # 例外が外に伝播しないこと
+    await reporter.update_task("t1", title="x", status=STATUS_IN_PROGRESS)
+    await reporter.finish()
 
 
 @pytest.mark.asyncio

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,189 @@
+"""進捗 reporter (Plan Block / テキスト / 遅延 / フォールバック) を検証する (Issue #6)。"""
+
+import pytest
+
+from slack_agent.progress import (
+    STATUS_COMPLETE,
+    STATUS_IN_PROGRESS,
+    LazyReporter,
+    PlanBlockReporter,
+    TextProgressReporter,
+    create_reporter,
+)
+
+
+class _RecordingClient:
+    """Slack client のモック。呼び出しを記録する。"""
+
+    def __init__(self, start_stream_error: Exception | None = None):
+        self._start_stream_error = start_stream_error
+        self.calls: list[tuple] = []
+
+    async def chat_startStream(self, **kwargs):
+        self.calls.append(("startStream", kwargs))
+        if self._start_stream_error is not None:
+            raise self._start_stream_error
+        return {"ts": "stream-1"}
+
+    async def chat_appendStream(self, **kwargs):
+        self.calls.append(("appendStream", kwargs))
+        return {"ok": True}
+
+    async def chat_stopStream(self, **kwargs):
+        self.calls.append(("stopStream", kwargs))
+        return {"ok": True}
+
+    async def chat_postMessage(self, **kwargs):
+        self.calls.append(("postMessage", kwargs))
+        return {"ts": "msg-1"}
+
+    async def chat_update(self, **kwargs):
+        self.calls.append(("update", kwargs))
+        return {"ok": True}
+
+    def kinds(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
+# ---- PlanBlockReporter ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plan_block_starts_stream_with_plan_mode():
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(client, "C1", "100")
+    await reporter.start()
+
+    kind, kwargs = client.calls[0]
+    assert kind == "startStream"
+    assert kwargs["channel"] == "C1"
+    assert kwargs["thread_ts"] == "100"
+    assert kwargs["task_display_mode"] == "plan"
+
+
+@pytest.mark.asyncio
+async def test_plan_block_appends_task_chunks_and_status_transition():
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(client, "C1", "100")
+    await reporter.start()
+
+    await reporter.update_task("t1", title="Search workspace", status=STATUS_IN_PROGRESS)
+    await reporter.update_task("t1", status=STATUS_COMPLETE)
+
+    appends = [kwargs for kind, kwargs in client.calls if kind == "appendStream"]
+    assert len(appends) == 2
+
+    chunk1 = appends[0]["chunks"][0]
+    assert chunk1 == {
+        "type": "task",
+        "id": "t1",
+        "text": "Search workspace",
+        "status": STATUS_IN_PROGRESS,
+    }
+    # status 更新時も title は保持される
+    chunk2 = appends[1]["chunks"][0]
+    assert chunk2["text"] == "Search workspace"
+    assert chunk2["status"] == STATUS_COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_plan_block_includes_output_when_given():
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(client, "C1", "100")
+    await reporter.start()
+    await reporter.update_task("t1", title="x", status=STATUS_COMPLETE, output="done")
+
+    chunk = client.calls[-1][1]["chunks"][0]
+    assert chunk["output"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_plan_block_finish_stops_stream():
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(client, "C1", "100")
+    await reporter.start()
+    await reporter.finish()
+    assert client.kinds()[-1] == "stopStream"
+
+
+# ---- TextProgressReporter ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_reporter_posts_then_updates():
+    client = _RecordingClient()
+    reporter = TextProgressReporter(client, "C1", "100")
+    await reporter.start()
+    # start では投稿しない (遅延)
+    assert client.calls == []
+
+    await reporter.update_task("t1", title="first", status=STATUS_IN_PROGRESS)
+    await reporter.update_task("t1", status=STATUS_COMPLETE)
+
+    assert client.kinds() == ["postMessage", "update"]
+    # 最初の投稿は postMessage、以降は同じ ts を update
+    assert client.calls[1][1]["ts"] == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_text_reporter_renders_multiple_tasks_in_order():
+    client = _RecordingClient()
+    reporter = TextProgressReporter(client, "C1", "100")
+    await reporter.start()
+    await reporter.update_task("t1", title="alpha", status=STATUS_COMPLETE)
+    await reporter.update_task("t2", title="beta", status=STATUS_IN_PROGRESS)
+
+    last_text = client.calls[-1][1]["text"]
+    assert "alpha" in last_text
+    assert "beta" in last_text
+    assert last_text.index("alpha") < last_text.index("beta")
+
+
+# ---- create_reporter (fallback) -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_reporter_auto_uses_plan_when_available():
+    client = _RecordingClient()
+    reporter = await create_reporter(client, "C1", "100", mode="auto")
+    assert isinstance(reporter, PlanBlockReporter)
+
+
+@pytest.mark.asyncio
+async def test_create_reporter_auto_falls_back_to_text_on_error():
+    client = _RecordingClient(start_stream_error=RuntimeError("not enabled"))
+    reporter = await create_reporter(client, "C1", "100", mode="auto")
+    assert isinstance(reporter, TextProgressReporter)
+
+
+@pytest.mark.asyncio
+async def test_create_reporter_text_mode_forces_text():
+    client = _RecordingClient()
+    reporter = await create_reporter(client, "C1", "100", mode="text")
+    assert isinstance(reporter, TextProgressReporter)
+
+
+# ---- LazyReporter --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lazy_reporter_defers_creation_until_first_task():
+    client = _RecordingClient()
+    reporter = LazyReporter(client, "C1", "100", mode="auto")
+    await reporter.start()
+    # まだ何も投稿していない
+    assert client.calls == []
+
+    await reporter.update_task("t1", title="x", status=STATUS_IN_PROGRESS)
+    # 初回 update で startStream が走る
+    assert client.kinds()[0] == "startStream"
+
+
+@pytest.mark.asyncio
+async def test_lazy_reporter_finish_without_tasks_is_noop():
+    client = _RecordingClient()
+    reporter = LazyReporter(client, "C1", "100", mode="auto")
+    await reporter.start()
+    await reporter.finish()
+    # タスクが一度も無ければ Slack 呼び出しは発生しない
+    assert client.calls == []

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -59,6 +59,34 @@ async def test_plan_block_starts_stream_with_plan_mode():
     assert kwargs["channel"] == "C1"
     assert kwargs["thread_ts"] == "100"
     assert kwargs["task_display_mode"] == "plan"
+    # 未指定なら recipient_* は送らない
+    assert "recipient_team_id" not in kwargs
+    assert "recipient_user_id" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_plan_block_passes_recipient_ids_when_given():
+    """recipient_team_id は startStream に必須なので渡されたら送る。"""
+    client = _RecordingClient()
+    reporter = PlanBlockReporter(
+        client, "C1", "100",
+        recipient_team_id="T123", recipient_user_id="U456",
+    )
+    await reporter.start()
+
+    _, kwargs = client.calls[0]
+    assert kwargs["recipient_team_id"] == "T123"
+    assert kwargs["recipient_user_id"] == "U456"
+
+
+@pytest.mark.asyncio
+async def test_create_reporter_auto_forwards_recipient_team_id():
+    """auto モードでも recipient_team_id が startStream に伝播する。"""
+    client = _RecordingClient()
+    await create_reporter(client, "C1", "100", mode="auto", recipient_team_id="T999")
+
+    start_calls = [kwargs for kind, kwargs in client.calls if kind == "startStream"]
+    assert start_calls and start_calls[0]["recipient_team_id"] == "T999"
 
 
 @pytest.mark.asyncio

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -43,6 +43,34 @@ def test_should_retry_plain_exception_is_retryable():
     assert _should_retry_exception(ValueError("boom")) is True
 
 
+# クラス名で判定されるため、実物の mcp SDK と同じ "McpError" にする。
+class McpError(Exception):
+    """mcp SDK の McpError を模した例外 (クラス名で非リトライ判定される)。"""
+
+
+def test_should_retry_mcp_error_is_not_retryable():
+    """MCP タイムアウト (McpError) は再試行しても無駄なので非リトライ。"""
+    assert _should_retry_exception(McpError("Timed out ... Waited 60.0 seconds.")) is False
+
+
+def test_should_retry_timeout_error_is_not_retryable():
+    assert _should_retry_exception(TimeoutError("timed out")) is False
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_retry_mcp_timeout():
+    """McpError は 1 回で即座に失敗し、リトライで時間を浪費しない。"""
+    calls = []
+
+    async def func():
+        calls.append(1)
+        raise McpError("Timed out while waiting for response to ClientRequest. Waited 60.0 seconds.")
+
+    with pytest.raises(McpError):
+        await retry_async(func, max_attempts=3, backoff_base=0)
+    assert len(calls) == 1
+
+
 @pytest.mark.asyncio
 async def test_retry_returns_on_success():
     calls = []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from slack_agent.retry import _should_retry_exception, retry_async
+from slack_agent.retry import (
+    _describe_exception,
+    _should_retry_exception,
+    retry_async,
+)
 
 
 class _HTTPError(Exception):
@@ -101,3 +105,25 @@ async def test_retry_passes_through_args_and_kwargs():
 
     result = await retry_async(func, 1, 2, max_attempts=1, backoff_base=0, c=3)
     assert result == 6
+
+
+def test_describe_exception_plain():
+    assert _describe_exception(ValueError("boom")) == "ValueError: boom"
+
+
+def test_describe_exception_unwraps_exception_group():
+    """TaskGroup の ExceptionGroup は sub-exception を展開して見せる。"""
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [TimeoutError("read timed out"), ConnectionError("broken pipe")],
+    )
+    desc = _describe_exception(group)
+    assert "TimeoutError: read timed out" in desc
+    assert "ConnectionError: broken pipe" in desc
+
+
+def test_describe_exception_nested_group():
+    inner = ExceptionGroup("inner", [RuntimeError("deep")])
+    outer = ExceptionGroup("outer", [inner])
+    desc = _describe_exception(outer)
+    assert "RuntimeError: deep" in desc

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,17 +1,17 @@
 """MCP ツールラッパーの挙動を検証する。
 
-主目的は call_tool への read_timeout_seconds 伝播 (応答が返らない MCP
-サーバーで無限ハングしないため)。stdio_client / ClientSession をモックして
-_arun が call_tool に渡す引数を捕捉する。
+主目的:
+- call_tool への read_timeout_seconds 伝播 (応答が返らない MCP サーバーで
+  無限ハングしないため)。
+- 保持したセッションを使い回し、ツール呼び出しごとにサーバーを起動し直さない
+  こと (Issue #6 の再起動レース対策)。
 """
 
-import sys
-import types
+import asyncio
 from datetime import timedelta
 
 import pytest
 
-from slack_agent import tools as tools_mod
 from slack_agent.tools import _make_langchain_tool
 
 
@@ -27,71 +27,62 @@ class _FakeResult:
 
 
 class _FakeSession:
-    """ClientSession のモック。call_tool の引数を記録する。"""
+    """ClientSession のモック。call_tool の呼び出しを記録する。"""
 
-    last_call_kwargs: dict = {}
-
-    def __init__(self, read, write):
-        pass
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *exc):
-        return False
-
-    async def initialize(self):
-        return None
+    def __init__(self):
+        self.calls: list[dict] = []
 
     async def call_tool(self, name, arguments=None, read_timeout_seconds=None, **kw):
-        _FakeSession.last_call_kwargs = {
-            "name": name,
-            "arguments": arguments,
-            "read_timeout_seconds": read_timeout_seconds,
-        }
+        self.calls.append(
+            {
+                "name": name,
+                "arguments": arguments,
+                "read_timeout_seconds": read_timeout_seconds,
+            }
+        )
         return _FakeResult()
 
 
-class _FakeStdioClient:
-    """stdio_client(params) のモック (async context manager)。"""
-
-    def __init__(self, params):
-        pass
-
-    async def __aenter__(self):
-        return ("read", "write")
-
-    async def __aexit__(self, *exc):
-        return False
-
-
-@pytest.fixture(autouse=True)
-def _patch_mcp(monkeypatch):
-    monkeypatch.setattr(tools_mod, "stdio_client", lambda params: _FakeStdioClient(params))
-    monkeypatch.setattr(tools_mod, "ClientSession", _FakeSession)
-    _FakeSession.last_call_kwargs = {}
+def _make_tool(mcp_tool=None, session=None, timeout=None):
+    session = session or _FakeSession()
+    tool = _make_langchain_tool(
+        "srv", mcp_tool or _FakeMcpTool(), session, asyncio.Lock(), timeout
+    )
+    return tool, session
 
 
 @pytest.mark.asyncio
 async def test_tool_passes_read_timeout_as_timedelta():
-    tool = _make_langchain_tool("srv", _FakeMcpTool(), object(), tool_timeout_seconds=30.0)
+    tool, session = _make_tool(timeout=30.0)
     result = await tool.ainvoke({"q": "hello"})
 
     assert result == "tool output"
-    kwargs = _FakeSession.last_call_kwargs
-    assert kwargs["name"] == "search"
-    assert kwargs["read_timeout_seconds"] == timedelta(seconds=30.0)
+    call = session.calls[0]
+    assert call["name"] == "search"
+    assert call["arguments"] == {"q": "hello"}
+    assert call["read_timeout_seconds"] == timedelta(seconds=30.0)
 
 
 @pytest.mark.asyncio
 async def test_tool_no_timeout_passes_none():
-    tool = _make_langchain_tool("srv", _FakeMcpTool(), object(), tool_timeout_seconds=None)
+    tool, session = _make_tool(timeout=None)
     await tool.ainvoke({"q": "hello"})
-
-    assert _FakeSession.last_call_kwargs["read_timeout_seconds"] is None
+    assert session.calls[0]["read_timeout_seconds"] is None
 
 
 @pytest.mark.asyncio
 async def test_tool_name_is_prefixed_with_server():
-    tool = _make_langchain_tool("srv", _FakeMcpTool(name="fetch"), object())
+    tool, _ = _make_tool(mcp_tool=_FakeMcpTool(name="fetch"))
     assert tool.name == "srv__fetch"
+
+
+@pytest.mark.asyncio
+async def test_tool_reuses_same_session_across_calls():
+    """複数回呼んでも同じ保持セッションを使い、起動し直さない。"""
+    tool, session = _make_tool()
+    await tool.ainvoke({"q": "a"})
+    await tool.ainvoke({"q": "b"})
+
+    # 同一セッションに 2 回 call_tool されている (再接続していない)
+    assert len(session.calls) == 2
+    assert [c["arguments"] for c in session.calls] == [{"q": "a"}, {"q": "b"}]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,7 +7,6 @@
   こと (Issue #6 の再起動レース対策)。
 """
 
-import asyncio
 from datetime import timedelta
 
 import pytest
@@ -46,7 +45,7 @@ class _FakeSession:
 def _make_tool(mcp_tool=None, session=None, timeout=None):
     session = session or _FakeSession()
     tool = _make_langchain_tool(
-        "srv", mcp_tool or _FakeMcpTool(), session, asyncio.Lock(), timeout
+        "srv", mcp_tool or _FakeMcpTool(), session, timeout
     )
     return tool, session
 
@@ -86,3 +85,36 @@ async def test_tool_reuses_same_session_across_calls():
     # 同一セッションに 2 回 call_tool されている (再接続していない)
     assert len(session.calls) == 2
     assert [c["arguments"] for c in session.calls] == [{"q": "a"}, {"q": "b"}]
+
+
+@pytest.mark.asyncio
+async def test_calls_are_not_serialized_so_a_hang_does_not_block_others():
+    """1 本がハングしても後続ツールが巻き添えにならない (直列化していない)。
+
+    同一セッションを共有する 2 ツールで、遅い方を並行起動しても速い方が
+    先に完了することを確認する。lock で直列化していると速い方も待たされる。
+    """
+    import asyncio
+
+    completed: list[str] = []
+
+    class _SlowSession:
+        async def call_tool(self, name, arguments=None, read_timeout_seconds=None, **kw):
+            if arguments.get("slow"):
+                await asyncio.sleep(0.1)
+                completed.append("slow")
+            else:
+                completed.append("fast")
+            return _FakeResult()
+
+    session = _SlowSession()
+    slow = _make_langchain_tool("srv", _FakeMcpTool(name="a"), session, None)
+    fast = _make_langchain_tool("srv", _FakeMcpTool(name="b"), session, None)
+
+    await asyncio.gather(
+        slow.ainvoke({"slow": True}),
+        fast.ainvoke({"slow": False}),
+    )
+
+    # 直列化されていなければ fast が slow より先に完了する
+    assert completed == ["fast", "slow"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,97 @@
+"""MCP ツールラッパーの挙動を検証する。
+
+主目的は call_tool への read_timeout_seconds 伝播 (応答が返らない MCP
+サーバーで無限ハングしないため)。stdio_client / ClientSession をモックして
+_arun が call_tool に渡す引数を捕捉する。
+"""
+
+import sys
+import types
+from datetime import timedelta
+
+import pytest
+
+from slack_agent import tools as tools_mod
+from slack_agent.tools import _make_langchain_tool
+
+
+class _FakeMcpTool:
+    def __init__(self, name="search"):
+        self.name = name
+        self.description = "desc"
+        self.inputSchema = {"type": "object", "properties": {}}
+
+
+class _FakeResult:
+    content = "tool output"
+
+
+class _FakeSession:
+    """ClientSession のモック。call_tool の引数を記録する。"""
+
+    last_call_kwargs: dict = {}
+
+    def __init__(self, read, write):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def initialize(self):
+        return None
+
+    async def call_tool(self, name, arguments=None, read_timeout_seconds=None, **kw):
+        _FakeSession.last_call_kwargs = {
+            "name": name,
+            "arguments": arguments,
+            "read_timeout_seconds": read_timeout_seconds,
+        }
+        return _FakeResult()
+
+
+class _FakeStdioClient:
+    """stdio_client(params) のモック (async context manager)。"""
+
+    def __init__(self, params):
+        pass
+
+    async def __aenter__(self):
+        return ("read", "write")
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _patch_mcp(monkeypatch):
+    monkeypatch.setattr(tools_mod, "stdio_client", lambda params: _FakeStdioClient(params))
+    monkeypatch.setattr(tools_mod, "ClientSession", _FakeSession)
+    _FakeSession.last_call_kwargs = {}
+
+
+@pytest.mark.asyncio
+async def test_tool_passes_read_timeout_as_timedelta():
+    tool = _make_langchain_tool("srv", _FakeMcpTool(), object(), tool_timeout_seconds=30.0)
+    result = await tool.ainvoke({"q": "hello"})
+
+    assert result == "tool output"
+    kwargs = _FakeSession.last_call_kwargs
+    assert kwargs["name"] == "search"
+    assert kwargs["read_timeout_seconds"] == timedelta(seconds=30.0)
+
+
+@pytest.mark.asyncio
+async def test_tool_no_timeout_passes_none():
+    tool = _make_langchain_tool("srv", _FakeMcpTool(), object(), tool_timeout_seconds=None)
+    await tool.ainvoke({"q": "hello"})
+
+    assert _FakeSession.last_call_kwargs["read_timeout_seconds"] is None
+
+
+@pytest.mark.asyncio
+async def test_tool_name_is_prefixed_with_server():
+    tool = _make_langchain_tool("srv", _FakeMcpTool(name="fetch"), object())
+    assert tool.name == "srv__fetch"


### PR DESCRIPTION
# What

ツール実行の進捗表示を Slack の Plan Block（`chat.startStream` / `chat.appendStream` によるストリーミング）に対応させる。tool_call を 1 タスクとしてマッピングし、`pending → in_progress → complete` と状態を進める。Plan Block 非対応の環境（`assistant:write` スコープ無し / AI agent 機能未有効化）では自動でテキスト表示にフォールバックする。

closes #6

# Changes

- (feat): `progress.py` を追加。`ProgressReporter` 抽象と `PlanBlockReporter` / `TextProgressReporter` / `LazyReporter`、auto フォールバックする `create_reporter` ファクトリ
- (feat): `tool_executor_node` が tool_call ごとに task の状態遷移を reporter へ emit
- (feat): `graph.py` で `progress_reporter` を configurable 経由で配線。`slack_handler.py` が reporter を生成・終了
- (feat): `agent.progress_mode` 設定（auto/plan/text）を追加
- (refactor): 未使用化した `pending_progress_message` state フィールドと `_build_pending_message` を削除
- (test): `test_progress.py` 追加。reporter のストリーム制御・状態遷移・フォールバック・遅延生成を検証。`test_graph_flow.py` に reporter 連携の統合テストを追加
- (docs): README / tests README を更新