### PR TITLE
feat: add responding status to Plan Block before final answer

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,11 @@ if os.environ.get("DEBUG_LLM"):
 else:
     logging.basicConfig(level=logging.INFO)
 
+# DEBUG_PROGRESS=1 で Plan Block の chat.startStream/appendStream リクエスト・
+# レスポンスだけを DEBUG 出力する (LLM 入出力を巻き込まず調査したい場合用)。
+if os.environ.get("DEBUG_PROGRESS"):
+    logging.getLogger("slack_agent.progress").setLevel(logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 

--- a/slack_agent/progress.py
+++ b/slack_agent/progress.py
@@ -23,6 +23,12 @@ STATUS_IN_PROGRESS = "in_progress"
 STATUS_COMPLETE = "complete"
 STATUS_ERROR = "error"
 
+# 応答生成全体を表す最上位タスク。ツール呼び出しタスクが全て complete に
+# なった瞬間、これが無いと Plan Block 全体が complete 扱いになり見出しの
+# 表示が完了扱いになってしまう。最初に追加するタスクとして起動時に
+# in_progress にし、最終回答が確定したときだけ complete にする。
+RESPONDING_TASK_ID = "__responding__"
+
 # task_update chunk の title / output は 256 文字制限がある
 _PLAN_TEXT_LIMIT = 256
 
@@ -233,10 +239,7 @@ class TextProgressReporter(ProgressReporter):
 
 
 class LazyReporter(ProgressReporter):
-    """初回の update_task まで実際の reporter 生成 (= Slack 投稿) を遅延する。
-
-    tool_call が無く即答するケースで空のストリーム/メッセージを作らないため。
-    """
+    """初回の update_task まで実際の reporter 生成 (= Slack 投稿) を遅延する。"""
 
     def __init__(
         self,

--- a/slack_agent/progress.py
+++ b/slack_agent/progress.py
@@ -109,7 +109,9 @@ class PlanBlockReporter(ProgressReporter):
             kwargs["recipient_team_id"] = self._recipient_team_id
         if self._recipient_user_id is not None:
             kwargs["recipient_user_id"] = self._recipient_user_id
+        logger.debug("chat.startStream request kwargs=%r", kwargs)
         result = await self._client.chat_startStream(**kwargs)
+        logger.debug("chat.startStream response=%r", result)
         self._stream_ts = result["ts"]
 
     async def update_task(
@@ -140,11 +142,13 @@ class PlanBlockReporter(ProgressReporter):
             chunk["details"] = _truncate(details)
         if output is not None:
             chunk["output"] = _truncate(output)
-        await self._client.chat_appendStream(
+        logger.debug("chat.appendStream request chunk=%r", chunk)
+        result = await self._client.chat_appendStream(
             channel=self._channel,
             ts=self._stream_ts,
             chunks=[chunk],
         )
+        logger.debug("chat.appendStream response=%r", result)
 
     async def finish(self) -> None:
         if self._stream_ts is None:

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -7,7 +7,7 @@ from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
 from .config import AppConfig
-from .progress import LazyReporter
+from .progress import RESPONDING_TASK_ID, STATUS_COMPLETE, STATUS_IN_PROGRESS, LazyReporter
 from .state import AgentState
 from .thread_history import fetch_new_replies
 
@@ -145,7 +145,6 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             logger.info("  new_replies[%d]: %r", i, str(m.content)[:80])
 
         # 進捗表示: Plan Block (対応環境) またはテキストにフォールバック (Issue #6)。
-        # 初回タスクまで実際の投稿は遅延される。
         # chat.startStream はチャンネルへのストリーミングで recipient_team_id と
         # recipient_user_id が両方必須。event/body から取得する。
         team_id = body.get("team_id") or event.get("team")
@@ -156,6 +155,15 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             mode=agent_config.progress_mode,
             recipient_team_id=team_id,
             recipient_user_id=user_id,
+        )
+
+        # 「回答を生成中…」を最上位タスクとして先に追加する。ツールタスクが
+        # 全て complete になった瞬間だけこれが無いと Plan Block 全体の見出しが
+        # complete 扱いになってしまうため、実行全体を覆うタスクとして扱う。
+        await progress_reporter.update_task(
+            RESPONDING_TASK_ID,
+            title="回答を生成中…",
+            status=STATUS_IN_PROGRESS,
         )
 
         current_human = HumanMessage(content=text)
@@ -183,6 +191,12 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
             logger.exception("Agent failed: %s", exc)
             answer = _ERROR_MESSAGE
         finally:
+            try:
+                await progress_reporter.update_task(
+                    RESPONDING_TASK_ID, status=STATUS_COMPLETE
+                )
+            except Exception as exc:
+                logger.warning("Failed to complete responding task: %s", exc)
             try:
                 await progress_reporter.finish()
             except Exception as exc:


### PR DESCRIPTION
# What

- feat: show a "応答を生成中…" task in Plan Block while the orchestrator generates the next response after a tool call, instead of leaving the last tool task stuck at complete
- test: cover the new responding status transition and its absence on tool-free immediate answers