### PR TITLE
fix(slack): guard against empty response causing no_text error

### DIFF
--- a/slack_agent/nodes.py
+++ b/slack_agent/nodes.py
@@ -59,6 +59,13 @@ async def orchestrator_node(
         backoff_base=retry_config.backoff_base_seconds,
     )
 
+    if not str(response.content).strip() and not response.tool_calls:
+        logger.warning(
+            "orchestrator response has empty content and no tool_calls "
+            "(stop_reason=%r)",
+            response.response_metadata.get("stop_reason"),
+        )
+
     return {
         "messages": [response],
     }

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -15,16 +15,27 @@ logger = logging.getLogger(__name__)
 
 _ERROR_MESSAGE = "申し訳ありません。エラーが発生しました。しばらくしてから再度お試しください。"
 _EMPTY_RESPONSE_MESSAGE = "回答を生成できませんでした。もう一度お試しください。"
+# stop_reason=refusal は Claude の安全性分類器がリクエストを拒否した場合に返る値。
+# 同じ入力なら再試行しても同じ結果になりやすいため、通常の空応答とは別の文言で
+# 「入力側に問題がありそう」と伝える (「もう一度お試しください」は誤誘導になる)。
+_REFUSAL_MESSAGE = (
+    "この内容には応答できませんでした。参照した内容がモデルの安全性フィルタに"
+    "引っかかった可能性があります。質問の仕方や参照先を変えてお試しください。"
+)
 _MENTION_PATTERN = re.compile(r"<@[^>]+>")
 
 
-def _ensure_non_empty_answer(answer: str, *, thread_ts: str) -> str:
+def _ensure_non_empty_answer(answer: str, *, thread_ts: str, stop_reason: str | None = None) -> str:
     """Slack の chat.postMessage は空文字列の text で no_text エラーになるため、
     エージェントの最終応答が空だった場合はフォールバック文言に置き換える。
     """
     if answer.strip():
         return answer
-    logger.warning("Agent returned empty content (thread=%s)", thread_ts)
+    logger.warning(
+        "Agent returned empty content (thread=%s stop_reason=%r)", thread_ts, stop_reason
+    )
+    if stop_reason == "refusal":
+        return _REFUSAL_MESSAGE
     return _EMPTY_RESPONSE_MESSAGE
 
 
@@ -195,7 +206,10 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
                 },
             )
             final_message = final_state["messages"][-1]
-            answer = _ensure_non_empty_answer(str(final_message.content), thread_ts=thread_ts)
+            stop_reason = getattr(final_message, "response_metadata", {}).get("stop_reason")
+            answer = _ensure_non_empty_answer(
+                str(final_message.content), thread_ts=thread_ts, stop_reason=stop_reason
+            )
         except Exception as exc:
             logger.exception("Agent failed: %s", exc)
             answer = _ERROR_MESSAGE

--- a/slack_agent/slack_handler.py
+++ b/slack_agent/slack_handler.py
@@ -14,7 +14,18 @@ from .thread_history import fetch_new_replies
 logger = logging.getLogger(__name__)
 
 _ERROR_MESSAGE = "申し訳ありません。エラーが発生しました。しばらくしてから再度お試しください。"
+_EMPTY_RESPONSE_MESSAGE = "回答を生成できませんでした。もう一度お試しください。"
 _MENTION_PATTERN = re.compile(r"<@[^>]+>")
+
+
+def _ensure_non_empty_answer(answer: str, *, thread_ts: str) -> str:
+    """Slack の chat.postMessage は空文字列の text で no_text エラーになるため、
+    エージェントの最終応答が空だった場合はフォールバック文言に置き換える。
+    """
+    if answer.strip():
+        return answer
+    logger.warning("Agent returned empty content (thread=%s)", thread_ts)
+    return _EMPTY_RESPONSE_MESSAGE
 
 
 class ThreadLockManager:
@@ -184,7 +195,7 @@ def create_app(config: AppConfig, compiled_graph, agent_config) -> AsyncApp:
                 },
             )
             final_message = final_state["messages"][-1]
-            answer = str(final_message.content)
+            answer = _ensure_non_empty_answer(str(final_message.content), thread_ts=thread_ts)
         except Exception as exc:
             logger.exception("Agent failed: %s", exc)
             answer = _ERROR_MESSAGE

--- a/tests/test_slack_handler.py
+++ b/tests/test_slack_handler.py
@@ -6,6 +6,7 @@ import pytest
 
 from slack_agent.slack_handler import (
     _EMPTY_RESPONSE_MESSAGE,
+    _REFUSAL_MESSAGE,
     _ensure_non_empty_answer,
     ThreadLockManager,
 )
@@ -139,3 +140,11 @@ def test_ensure_non_empty_answer_passes_through_non_empty_text():
 def test_ensure_non_empty_answer_falls_back_on_empty_text(answer):
     """空文字列や空白のみの応答はフォールバック文言に置き換える (no_text エラー防止)。"""
     assert _ensure_non_empty_answer(answer, thread_ts="100") == _EMPTY_RESPONSE_MESSAGE
+
+
+def test_ensure_non_empty_answer_uses_refusal_message_on_refusal_stop_reason():
+    """stop_reason=refusal は Claude の安全性分類器による拒否なので、
+    再試行を促す通常の空応答メッセージとは別の専用文言を返す。"""
+    answer = _ensure_non_empty_answer("", thread_ts="100", stop_reason="refusal")
+    assert answer == _REFUSAL_MESSAGE
+    assert answer != _EMPTY_RESPONSE_MESSAGE

--- a/tests/test_slack_handler.py
+++ b/tests/test_slack_handler.py
@@ -1,10 +1,14 @@
-"""ThreadLockManager の直列化・即時解放挙動を検証する (Issue #4)。"""
+"""ThreadLockManager の直列化・即時解放挙動、および空応答ガードを検証する。"""
 
 import asyncio
 
 import pytest
 
-from slack_agent.slack_handler import ThreadLockManager
+from slack_agent.slack_handler import (
+    _EMPTY_RESPONSE_MESSAGE,
+    _ensure_non_empty_answer,
+    ThreadLockManager,
+)
 
 
 @pytest.mark.asyncio
@@ -124,3 +128,14 @@ async def test_release_unknown_key_is_safe():
     manager = ThreadLockManager()
     await manager.release("never-acquired")
     assert manager.active_count() == 0
+
+
+def test_ensure_non_empty_answer_passes_through_non_empty_text():
+    """通常の応答はそのまま返す。"""
+    assert _ensure_non_empty_answer("こんにちは", thread_ts="100") == "こんにちは"
+
+
+@pytest.mark.parametrize("answer", ["", "   ", "\n"])
+def test_ensure_non_empty_answer_falls_back_on_empty_text(answer):
+    """空文字列や空白のみの応答はフォールバック文言に置き換える (no_text エラー防止)。"""
+    assert _ensure_non_empty_answer(answer, thread_ts="100") == _EMPTY_RESPONSE_MESSAGE


### PR DESCRIPTION
# What

- fix: fall back to a placeholder message when the agent's final response is empty, avoiding Slack's no_text error
- fix: log stop_reason (no message content) when orchestrator returns empty content with no tool_calls, to help diagnose the cause
- test: add coverage for the empty-response fallback guard