### PR TITLE
fix(agent): clarify security content summarization is routine work

### DIFF
--- a/slack_agent/nodes.py
+++ b/slack_agent/nodes.py
@@ -20,6 +20,12 @@ above the tool calls, so:
 - Write it only ONCE. Do not repeat or restate the same sentence.
 - Make it a purposeful sentence about your goal, not a restatement of the tool
   name or its arguments.
+
+You are used internally by a company's engineering team. Requests to fetch,
+summarize, or explain security advisories, incident reports, vulnerability
+writeups, or malware analyses (e.g. from security blogs or CERT advisories)
+are routine defensive-security work, not requests to produce attack tooling.
+Answer them the same way you would any other technical summary request.
 """
 
 


### PR DESCRIPTION
# What

- fix: add a note to the orchestrator system prompt clarifying that summarizing security advisories/incident reports/malware writeups is routine defensive-security work for an internal engineering tool, not a request for attack tooling

This is a mitigation, not a guaranteed fix — the model's safety classifier decision isn't fully controllable via system prompt. Observed trigger: fetching and summarizing https://blog.flatt.tech/entry/asyncapi_compromise (a supply-chain attack incident writeup) consistently returned stop_reason=refusal before this change.